### PR TITLE
Fix az webapp remote-connection 

### DIFF
--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -305,6 +305,13 @@ namespace Kudu.Services.Web
                 app.UseExceptionHandler("/Error");
             }
 
+
+            var webSocketOptions = new WebSocketOptions()
+            {
+                KeepAliveInterval = TimeSpan.FromSeconds(15)
+            };
+            app.UseWebSockets(webSocketOptions);
+
             var containsRelativePath = new Func<HttpContext, bool>(i =>
                 i.Request.Path.Value.StartsWith("/Default", StringComparison.OrdinalIgnoreCase));
 

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kudu.Contracts\Kudu.Contracts.csproj" />


### PR DESCRIPTION
This CLI call relies on web socket requests. For .NET core apps, to use web socket, we need to specifically configure the app to do so at Configure()