### PR TITLE
Increasing deployments lock timeout to 20 minutes

### DIFF
--- a/Kudu.Core/AllSafeLinuxLock.cs
+++ b/Kudu.Core/AllSafeLinuxLock.cs
@@ -19,6 +19,7 @@ namespace Kudu.Core
     {
         private ITraceFactory _traceFactory;
         private static readonly string locksPath = "/home/site/locks";
+	private const int lockTimeout = 1200; //in seconds
         public AllSafeLinuxLock(string path, ITraceFactory traceFactory)
         {
             _traceFactory = traceFactory;
@@ -104,7 +105,7 @@ namespace Kudu.Core
             lockInfo.heldByTID = Thread.CurrentThread.ManagedThreadId;
             lockInfo.heldByWorker = System.Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
             lockInfo.heldByOp = operationName;
-            lockInfo.lockExpiry = DateTime.UtcNow.AddSeconds(600);
+            lockInfo.lockExpiry = DateTime.UtcNow.AddSeconds(lockTimeout);
             //Console.WriteLine("CreatingLockDir - LockInfoObj : "+lockInfo);
             var json = JsonConvert.SerializeObject(lockInfo);
             FileSystemHelpers.WriteAllText(locksPath+"/deployment/info.lock",json);


### PR DESCRIPTION
Increased the timeout to avoid bug where long running build script timeouts invalidate the deployment locks.

This would be fixed in future by Heartbeats between build script and locks to bump up its expiry.