### PR TITLE
Increasing log stream timeout and new line fix

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -8,7 +8,7 @@ namespace Kudu.Contracts.Settings
     public static class DeploymentSettingsExtension
     {
         public static readonly TimeSpan DefaultCommandIdleTimeout = TimeSpan.FromMinutes(1);
-        public static readonly TimeSpan DefaultLogStreamTimeout = TimeSpan.FromMinutes(30);
+        public static readonly TimeSpan DefaultLogStreamTimeout = TimeSpan.FromMinutes(120);
         public static readonly TimeSpan DefaultWebJobsRestartTime = TimeSpan.FromMinutes(1);
         public static readonly TimeSpan DefaultJobsIdleTimeout = TimeSpan.FromMinutes(2);
         public const TraceLevel DefaultTraceLevel = TraceLevel.Error;

--- a/Kudu.Services/DebugExtension/DebugExtensionMiddleware.cs
+++ b/Kudu.Services/DebugExtension/DebugExtensionMiddleware.cs
@@ -113,11 +113,22 @@ namespace Kudu.Services.TunnelServer
                 {
                 }
 
+                bool continueIpCheck = true;
+                int debugPort = 2222;
+
                 try
                 {
                     if (ipAddress == null)
                     {
                         ipAddress = System.IO.File.ReadAllText("/appsvctmp/ipaddr_" + Environment.GetEnvironmentVariable("WEBSITE_ROLE_INSTANCE_ID"));
+                        if(ipAddress != null && ipAddress.Contains(':'))
+                        {
+                            string[] ipAddrPortStr = ipAddress.Split(":");
+                            ipAddress = ipAddrPortStr[0];
+                            debugPort = Int32.Parse(ipAddrPortStr[1]);
+                            continueIpCheck = false;
+                            _logger.LogInformation("HandleWebSocketConnection: VNET Conatiner PORT : " + tunnelPort);
+                    }
                         _logger.LogInformation("HandleWebSocketConnection: Found IP Address from appsvctmp file: " + ipAddress);
                     }
                 }
@@ -127,7 +138,7 @@ namespace Kudu.Services.TunnelServer
 
                 try
                 {
-                    if (ipAddress == null)
+                    if (continueIpCheck && ipAddress == null)
                     {
                         ipAddress = System.IO.File.ReadAllText("/home/site/ipaddr_" + Environment.GetEnvironmentVariable("WEBSITE_ROLE_INSTANCE_ID"));
                         _logger.LogInformation("HandleWebSocketConnection: Found IP Address from share file: " + ipAddress);
@@ -144,20 +155,21 @@ namespace Kudu.Services.TunnelServer
 
                 _logger.LogInformation("HandleWebSocketConnection: Final IP Address: " + ipAddress);
 
-                int debugPort = 2222;
-
-                try
+                if (continueIpCheck)
                 {
-                    debugPort = Int32.Parse(Environment.GetEnvironmentVariable("APPSVC_TUNNEL_PORT"));
-
-                    if (debugPort <= 0)
+                    try
                     {
-                        throw new Exception("Debuggee not found. Please start your site in debug mode and then attach debugger.");
+                        debugPort = Int32.Parse(Environment.GetEnvironmentVariable("APPSVC_TUNNEL_PORT"));
+
+                       if (debugPort <= 0)
+                        {
+                            throw new Exception("Debuggee not found. Please start your site in debug mode and then attach debugger.");
+                        }
                     }
-                }
-                catch (Exception)
-                {
-                    debugPort = 2222;
+                    catch (Exception)
+                    {
+                        debugPort = 2222;
+                    }
                 }
 
                 string remoteDebug = "FALSE";

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -132,9 +132,7 @@ namespace Kudu.Services.Performance
                     foreach (string logLine in Tail(reader, 10))
                     {
                         await context.Response.WriteAsync(
-                            string.Format(System.Environment.NewLine, 
-                                logLine, 
-                                System.Environment.NewLine));
+                            string.Format(logLine,System.Environment.NewLine));
                     }
                 }
             }


### PR DESCRIPTION
This PR:

1. Increases the LogStream timeout to 120 minutes.
2. Removes an extra new line char from LogStream.
3. Adds VNET support to the tunnel extension.