### PR TITLE
Add support for .sh script in PostDepoymentActions

### DIFF
--- a/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
@@ -217,7 +217,7 @@ namespace Kudu.Core.Deployment.Generator
         {
             if (string.Equals(".sh", fi.Extension, StringComparison.OrdinalIgnoreCase))
             {
-                context.Logger.Log("Setting execute permissions for post build script " + fi.FullName);
+                context.Logger.Log("Add execute permission for post build script " + fi.FullName);
                 PermissionHelper.Chmod("ugo+x", fi.FullName, Environment, DeploymentSettings, context.Logger);
                 return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", fi.FullName);
             }
@@ -228,6 +228,7 @@ namespace Kudu.Core.Deployment.Generator
         {
             if (string.Equals(".ps1", fi.Extension, StringComparison.OrdinalIgnoreCase))
             {
+                context.Logger.Log("Execute post build script with RemoteSigned policy " + fi.FullName);
                 return string.Format(CultureInfo.InvariantCulture, "PowerShell.exe -ExecutionPolicy RemoteSigned -File \"{0}\"", fi.FullName);
             }
             return null;

--- a/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
@@ -65,11 +65,11 @@ namespace Kudu.Core.Deployment.Generator
 
                 if (OSDetector.IsOnWindows())
                 {
-                    scriptFilePath = GetWindowsPostBuildFilepath(fi);
+                    scriptFilePath = GetWindowsPostBuildFilepath(context, fi);
                 }
                 else if (!OSDetector.IsOnWindows())
                 {
-                    scriptFilePath = GetLinuxPostBuildFilepath(fi);
+                    scriptFilePath = GetLinuxPostBuildFilepath(context, fi);
                 }
 
                 if (string.IsNullOrEmpty(scriptFilePath))
@@ -213,16 +213,18 @@ namespace Kudu.Core.Deployment.Generator
             return scriptFilesGroupedAndSorted;
         }
 
-        private string GetLinuxPostBuildFilepath(FileInfo fi)
+        private string GetLinuxPostBuildFilepath(DeploymentContext context, FileInfo fi)
         {
             if (string.Equals(".sh", fi.Extension, StringComparison.OrdinalIgnoreCase))
             {
-                return string.Format(CultureInfo.InvariantCulture, "sh \"{0}\"", fi.FullName);
+                context.Logger.Log("Setting execute permissions for post build script " + fi.FullName);
+                PermissionHelper.Chmod("ugo+x", fi.FullName, Environment, DeploymentSettings, context.Logger);
+                return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", fi.FullName);
             }
             return null;
         }
 
-        private string GetWindowsPostBuildFilepath(FileInfo fi)
+        private string GetWindowsPostBuildFilepath(DeploymentContext context, FileInfo fi)
         {
             if (string.Equals(".ps1", fi.Extension, StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
### Feature Added
1. Add support for .sh script when Kudulite is running non Windows machine.

### Feature Changed
1. Prevent .ps1 file from running in non Windows environment. Since Linux container does not have /usr/bin/pwsh support yet.

This PR will address the issue: https://github.com/Azure-App-Service/KuduLite/issues/29
CR: @sanchitmehta 