### PR TITLE
Add URL support in api/zipdeploy endpoint

### DIFF
--- a/Kudu.Core/Deployment/ZipDeploymentInfo.cs
+++ b/Kudu.Core/Deployment/ZipDeploymentInfo.cs
@@ -32,5 +32,8 @@ namespace Kudu.Core.Deployment
         
         // This is used if the deployment is Run-From-Zip
         public string ZipName { get; set; }
+
+        // This is used when getting the zipfile from the zipURL
+        public string ZipURL { get; set; }
     }
 }

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -443,6 +443,9 @@ namespace Kudu.Services.Web
                 routes.MapRoute("zip-push-deploy", "api/zipdeploy",
                     new {controller = "PushDeployment", action = "ZipPushDeploy"},
                     new {verb = new HttpMethodRouteConstraint("POST")});
+                routes.MapRoute("zip-push-deploy-url", "api/zipdeploy",
+                    new {controller = "PushDeployment", action = "ZipPushDeployViaUrl"},
+                    new {verb = new HttpMethodRouteConstraint("PUT")});
                 routes.MapRoute("zip-war-deploy", "api/wardeploy",
                     new {controller = "PushDeployment", action = "WarPushDeploy"},
                     new {verb = new HttpMethodRouteConstraint("POST")});

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -15,6 +15,8 @@ using Kudu.Core.SourceControl;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json.Linq;
+using System.Net.Http;
 
 namespace Kudu.Services.Deployment
 {
@@ -71,7 +73,8 @@ namespace Kudu.Services.Deployment
                     DoFullBuildByDefault = false,
                     Author = author,
                     AuthorEmail = authorEmail,
-                    Message = message
+                    Message = message,
+                    ZipURL = null
                 };
 
                 if (_settings.RunFromLocalZip())
@@ -88,6 +91,41 @@ namespace Kudu.Services.Deployment
 
                 ;
 
+                return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
+            }
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> ZipPushDeployViaUrl(
+            [FromBody] JObject requestJson,
+            [FromQuery] bool isAsync = false,
+            [FromQuery] string author = null,
+            [FromQuery] string authorEmail = null,
+            [FromQuery] string deployer = DefaultDeployer,
+            [FromQuery] string message = DefaultMessage)
+        {
+            using (_tracer.Step("ZipPushDeployViaUrl"))
+            {
+                string zipUrl = GetZipURLFromJSON(requestJson);
+
+                var deploymentInfo = new ZipDeploymentInfo(_environment, _traceFactory)
+                {
+                    AllowDeploymentWhileScmDisabled = true,
+                    Deployer = deployer,
+                    IsContinuous = false,
+                    AllowDeferredDeployment = false,
+                    IsReusable = false,
+                    TargetChangeset =
+                        DeploymentManager.CreateTemporaryChangeSet(message: "Deploying from pushed zip file"),
+                    CommitId = null,
+                    RepositoryType = RepositoryType.None,
+                    Fetch = LocalZipHandler,
+                    DoFullBuildByDefault = false,
+                    Author = author,
+                    AuthorEmail = authorEmail,
+                    Message = message,
+                    ZipURL = zipUrl,
+                };
                 return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
             }
         }
@@ -130,13 +168,39 @@ namespace Kudu.Services.Deployment
                     DoFullBuildByDefault = false,
                     Author = author,
                     AuthorEmail = authorEmail,
-                    Message = message
+                    Message = message,
+                    ZipURL = null
                 };
-
                 return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
             }
         }
 
+        private string GetZipURLFromJSON(JObject requestObject)
+        {
+            using (_tracer.Step("Reading the zip URL from the request JSON"))
+            {
+                try
+                {
+                    string packageUri = requestObject.Value<string>("packageUri");
+                    if (string.IsNullOrEmpty(packageUri))
+                    {
+                        throw new ArgumentException("Request body does not contain packageUri");
+                    }
+
+                    Uri zipUri = null;
+                    if (!Uri.TryCreate(packageUri, UriKind.Absolute, out zipUri))
+                    {
+                        throw new ArgumentException("Malformed packageUri");
+                    }
+                    return packageUri;
+                }
+                catch (Exception ex)
+                {
+                    _tracer.TraceError(ex, "Error reading the URL from the JSON {0}", requestObject.ToString());
+                    throw;
+                }
+            }
+        }
 
         private async Task<IActionResult> PushDeployAsync(ZipDeploymentInfo deploymentInfo, bool isAsync,
             HttpContext context)
@@ -159,6 +223,27 @@ namespace Kudu.Services.Deployment
                             using (var file = System.IO.File.Create(zipFilePath))
                             {
                                 formModel = await Request.StreamFile(file);
+                            }
+                        }
+                    }
+                    else if (deploymentInfo.ZipURL != null)
+                    {
+                        using (_tracer.Step("Writing zip file from packageUri to {0}", zipFilePath))
+                        {
+                            using (var file = System.IO.File.Create(zipFilePath))
+                            {
+                                using (var client = new HttpClient())
+                                {
+                                    var zipUrlResponse = await client.GetAsync(deploymentInfo.ZipURL);
+                                    if (zipUrlResponse.IsSuccessStatusCode)
+                                    {
+                                        await zipUrlResponse.Content.CopyToAsync(file);
+                                    }
+                                    else
+                                    {
+                                        _tracer.TraceError("Failed to get file from packageUri {0}", deploymentInfo.ZipURL);
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
We may want to support the basic scenario when a customer **PUT /api/zipdeploy** endpoint with a "application/json" body containing **packageUri**.

This feature does exist in the Kudu but it is removed from KuduLite.
My implementation does not support ARM Template deployment scenario. Please let me know if there's anything missing.

@ankitkumarr @JennyLawrance 