### PR TITLE
Fix issues with functionapp build

### DIFF
--- a/Kudu.Core/Deployment/Generator/OryxBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/OryxBuilder.cs
@@ -2,6 +2,8 @@
 using Kudu.Core.Helpers;
 using Kudu.Contracts.Settings;
 using Kudu.Core.Deployment.Oryx;
+using Kudu.Core.Infrastructure;
+using System.IO;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -41,6 +43,8 @@ namespace Kudu.Core.Deployment.Generator
            
             if (args.RunOryxBuild)
             {
+                PreOryxBuild(context);
+
                 string buildCommand = args.GenerateOryxBuildCommand(context);
                 RunCommand(context, buildCommand, false, "Running oryx build...");
 
@@ -53,6 +57,20 @@ namespace Kudu.Core.Deployment.Generator
             }
 
             return Task.CompletedTask;
+        }
+
+        public static void PreOryxBuild(DeploymentContext context)
+        {
+            if (FunctionAppHelper.LooksLikeFunctionApp())
+            {
+                // We need to delete this directory in order to avoid issues with
+                // reinstalling Python dependencies on a target directory
+                var pythonPackagesDir = Path.Combine(context.OutputPath, ".python_packages");
+                if (Directory.Exists(pythonPackagesDir))
+                {
+                    FileSystemHelpers.DeleteDirectorySafe(pythonPackagesDir);
+                }
+            }
         }
 
         //public override void PostBuild(DeploymentContext context)

--- a/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
@@ -94,20 +94,13 @@ namespace Kudu.Core.Deployment.Oryx
 
         private WorkerRuntime ResolveWorkerRuntime()
         {
-            // Note: FRAMEWORK is not set right now for a Function App. However, we are planning on doing so,
-            // similar to what AppService does. Once we start setting that, this should be the order of preference
-            var functionsWorkerRuntimeStr = GetEnvironmentVariableOrNull(OryxBuildConstants.OryxEnvVars.FrameworkSetting)
-                ?? GetEnvironmentVariableOrNull(OryxBuildConstants.FunctionAppEnvVars.WorkerRuntimeSetting);
-
+            var functionsWorkerRuntimeStr = GetEnvironmentVariableOrNull(OryxBuildConstants.FunctionAppEnvVars.WorkerRuntimeSetting);
             return FunctionAppSupportedWorkerRuntime.ParseWorkerRuntime(functionsWorkerRuntimeStr);
         }
 
         private string ResolveWorkerRuntimeVersion(WorkerRuntime workerRuntime)
         {
-            // Note: FRAMEWORK_VERSION is not set right now for a Function App. However, we are planning on doing so,
-            // similar to what AppService does. Until then, we will always hit the defaults
-            return GetEnvironmentVariableOrNull(OryxBuildConstants.OryxEnvVars.FrameworkVersionSetting)
-                ?? FunctionAppSupportedWorkerRuntime.GetDefaultLanguageVersion(workerRuntime);
+            return FunctionAppSupportedWorkerRuntime.GetDefaultLanguageVersion(workerRuntime);
         }
 
         private string GetEnvironmentVariableOrNull(string environmentVarName)


### PR DESCRIPTION
\cc @JennyLawrance 

We need to explicitly delete `.python_packages` to avoid issues with redeployment.

Additionally, for Function Apps, FRAMEWORK and FRAMEWORK_VERSION seem to be set by the platform, but the values are not what we expect. This is because the `linuxFxVersion` setting is used very differently by a Function App. Best to not use that, until platform has a better way to indicate the right version to kudulite for Function Apps.

Note: UseExpressBuild is currently not gonna work for Function App, because we try to zip up the entire directory. Maybe we need to use `WEBSITE_RUN_FROM_PACKAGE` + build settings. 