### PR TITLE
[functionapp] Allow KuduLite decrypts assignment context

### DIFF
--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -47,12 +47,7 @@
         public const string RunFromZip = "WEBSITE_RUN_FROM_PACKAGE";
         public const string MaxZipPackageCount = "SCM_MAX_ZIP_PACKAGE_COUNT";
         // Antares container specific settings
-        public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
-        public const string PlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
-        public const string ContainerReady = "WEBSITE_CONTAINER_READY";
-        public const string WebsiteHostname = "WEBSITE_HOSTNAME";
         public const string AuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
-        public const string MachineDecryptionKey = "MACHINEKEY_DecryptionKey";
     }
 }

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -46,5 +46,13 @@
         public const string RunFromZipOld = "WEBSITE_RUN_FROM_ZIP";  // Old name, will eventually go away
         public const string RunFromZip = "WEBSITE_RUN_FROM_PACKAGE";
         public const string MaxZipPackageCount = "SCM_MAX_ZIP_PACKAGE_COUNT";
+        // Antares container specific settings
+        public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
+        public const string PlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
+        public const string ContainerReady = "WEBSITE_CONTAINER_READY";
+        public const string WebsiteHostname = "WEBSITE_HOSTNAME";
+        public const string AuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
+        public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
+        public const string MachineDecryptionKey = "MACHINEKEY_DecryptionKey";
     }
 }

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -27,10 +27,10 @@
     <PackageReference Include="LibGit2Sharp" Version="0.25.2" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Mercurial.Net" Version="1.1.1.607" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />	    
-     <PackageReference Include="System.Text.RegularExpressions"/>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="0.1.78-alpha" />
     <PackageReference Include="ncrontab" Version="3.3.0" />
     <PackageReference Include="NuGet.Protocol" Version="4.8.0" />

--- a/Kudu.Services/Models/EncryptedHostAssignmentContext.cs
+++ b/Kudu.Services/Models/EncryptedHostAssignmentContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Kudu.Core.Helpers;
+
+namespace Kudu.Services.Models
+{
+    public class EncryptedHostAssignmentContext
+    {
+        [JsonProperty("encryptedContext")]
+        public string EncryptedContext { get; set; }
+
+        public static EncryptedHostAssignmentContext Create(HostAssignmentContext context, string key)
+        {
+            string json = JsonConvert.SerializeObject(context);
+            var encryptionKey = Convert.FromBase64String(key);
+            string encrypted = SimpleWebTokenHelper.Encrypt(json, encryptionKey);
+
+            return new EncryptedHostAssignmentContext { EncryptedContext = encrypted };
+        }
+
+        public HostAssignmentContext Decrypt(string key)
+        {
+            var decrypted = SimpleWebTokenHelper.Decrypt(key.ToKeyBytes(), EncryptedContext);
+            return JsonConvert.DeserializeObject<HostAssignmentContext>(decrypted);
+        }
+    }
+}

--- a/Kudu.Services/Models/HostAssignmentContext.cs
+++ b/Kudu.Services/Models/HostAssignmentContext.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Kudu.Contracts.Settings;
+using Kudu.Core;
+
+namespace Kudu.Services.Models
+{
+    public class HostAssignmentContext
+    {
+        [JsonProperty("siteId")]
+        public int SiteId { get; set; }
+
+        [JsonProperty("siteName")]
+        public string SiteName { get; set; }
+
+        [JsonProperty("environment")]
+        public Dictionary<string, string> Environment { get; set; }
+
+        [JsonProperty("lastModifiedTime")]
+        public DateTime LastModifiedTime { get; set; }
+
+        public string ZipUrl
+        {
+            get
+            {
+                if (Environment.ContainsKey(SettingsKeys.RunFromZip))
+                {
+                    return Environment[SettingsKeys.RunFromZip];
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+        }
+
+        public bool Equals(HostAssignmentContext other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return SiteId == other.SiteId && LastModifiedTime.CompareTo(other.LastModifiedTime) == 0;
+        }
+
+        public void ApplyAppSettings()
+        {
+            foreach (var pair in Environment)
+            {
+                System.Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+        }
+    }
+}

--- a/Kudu.Tests/Core/Helpers/SimpleWebTokenTests.cs
+++ b/Kudu.Tests/Core/Helpers/SimpleWebTokenTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.AspNetCore.Authentication;
+using Xunit;
+using Kudu.Core.Helpers;
+using Kudu.Contracts.Settings;
+
+namespace Kudu.Tests.Core.Helpers
+{
+    public class SimpleWebTokenTests
+    {
+        [Fact]
+        public void EncryptShouldThrowIdNoEncryptionKeyDefined()
+        {
+            // Make sure WEBSITE_AUTH_ENCRYPTION_KEY is empty
+            Environment.SetEnvironmentVariable("WEBSITE_AUTH_ENCRYPTION_KEY", string.Empty);
+
+            try
+            {
+                SimpleWebTokenHelper.Encrypt("value");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsType<InvalidOperationException>(ex);
+                Assert.Contains("WEBSITE_AUTH_ENCRYPTION_KEY", ex.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("value")]
+        public void EncryptShouldGenerateDecryptableValues(string valueToEncrypt)
+        {
+            var key = TestHelpers.GenerateKeyBytes();
+            var stringKey = TestHelpers.GenerateKeyHexString(key);
+            Environment.SetEnvironmentVariable("WEBSITE_AUTH_ENCRYPTION_KEY", stringKey);
+
+            var encrypted = SimpleWebTokenHelper.Encrypt(valueToEncrypt);
+            var decrypted = SimpleWebTokenHelper.Decrypt(key, encrypted);
+
+            Assert.Matches("(.*)[.](.*)[.](.*)", encrypted);
+            Assert.Equal(valueToEncrypt, decrypted);
+        }
+
+        [Fact]
+        public void CreateTokenShouldCreateAValidToken()
+        {
+            var key = TestHelpers.GenerateKeyBytes();
+            var stringKey = TestHelpers.GenerateKeyHexString(key);
+            var timeStamp = DateTime.UtcNow;
+            Environment.SetEnvironmentVariable("WEBSITE_AUTH_ENCRYPTION_KEY", stringKey);
+
+            var token = SimpleWebTokenHelper.CreateToken(timeStamp);
+            var decrypted = SimpleWebTokenHelper.Decrypt(key, token);
+
+            Assert.Equal($"exp={timeStamp.Ticks}", decrypted);
+        }
+
+        [Fact]
+        public void Validate_Token_Uses_WebSiteAuthEncryptionKey_If_Available()
+        {
+            var containerEncryptionKey = TestHelpers.GenerateKeyBytes();
+            var containerEncryptionStringKey = TestHelpers.GenerateKeyHexString(containerEncryptionKey);
+
+            var websiteAuthEncryptionKey = TestHelpers.GenerateKeyBytes();
+            var websiteAuthEncryptionStringKey = TestHelpers.GenerateKeyHexString(websiteAuthEncryptionKey);
+
+            var timeStamp = DateTime.UtcNow.AddHours(1);
+
+            Environment.SetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey, containerEncryptionStringKey);
+            Environment.SetEnvironmentVariable(SettingsKeys.AuthEncryptionKey, websiteAuthEncryptionStringKey);
+
+            var token = SimpleWebTokenHelper.CreateToken(timeStamp, websiteAuthEncryptionKey);
+            Assert.True(SimpleWebTokenHelper.TryValidateToken(token, new SystemClock()));
+        }
+
+        [Fact]
+        public void Validate_Token_Uses_Website_Encryption_Key_If_Container_Encryption_Key_Not_Available()
+        {
+            var websiteAuthEncryptionKey = TestHelpers.GenerateKeyBytes();
+            var websiteAuthEncryptionStringKey = TestHelpers.GenerateKeyHexString(websiteAuthEncryptionKey);
+
+            var timeStamp = DateTime.UtcNow.AddHours(1);
+
+            Environment.SetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey, string.Empty);
+            Environment.SetEnvironmentVariable(SettingsKeys.AuthEncryptionKey, websiteAuthEncryptionStringKey);
+
+            var token = SimpleWebTokenHelper.CreateToken(timeStamp, websiteAuthEncryptionKey);
+            Assert.True(SimpleWebTokenHelper.TryValidateToken(token, new SystemClock()));
+        }
+
+        public void Dispose()
+        {
+            // Clean up
+            Environment.SetEnvironmentVariable(SettingsKeys.AuthEncryptionKey, string.Empty);
+            Environment.SetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey, string.Empty);
+        }
+    }
+}

--- a/Kudu.Tests/Kudu.Tests.csproj
+++ b/Kudu.Tests/Kudu.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kudu.Core\Kudu.Core.csproj" />
+    <ProjectReference Include="..\Kudu.Services\Kudu.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Kudu.Tests/Services/Models/EncryptedHostAssignmentContextTests.cs
+++ b/Kudu.Tests/Services/Models/EncryptedHostAssignmentContextTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Kudu.Services.Models;
+using Xunit;
+
+namespace Kudu.Tests.Services.Models
+{
+    public class EncryptedHostAssignmentContextTests
+    {
+        private const string _encryptionKey = "MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=";
+        private const string _lastModifiedTime = "2019-01-15T15:53:00";
+        private HostAssignmentContext _context = new HostAssignmentContext() {
+            SiteId = 10,
+            SiteName = "sitename",
+            LastModifiedTime = DateTime.Parse(_lastModifiedTime),
+            Environment = new Dictionary<string, string>()
+            {
+                {"APPSETTING_AzureWebJobsStorage", "<StorageString>"},
+                {"APPSETTING_SCM_RUN_FROM_PACKAGE", "1"},
+                {"APPSETTING_SCM_DO_BUILD_DURING_DEPLOYMENT", "true"},
+                {"APPSETTING_SCM_NO_REPOSITORY", "1"},
+                {"ENABLE_ORYX_BUILD", "true"},
+                {"FRAMEWORK", "PYTHON"},
+                {"FRAMEWORK_VERSION", "3.6"}
+            }
+        };
+
+        [Fact]
+        public void EncryptedContextShouldExistAfterCreate()
+        {
+            var result = EncryptedHostAssignmentContext.Create(_context, _encryptionKey);
+            Assert.NotEmpty(result.EncryptedContext);
+        }
+
+        [Fact]
+        public void DecryptedContextShouldMatchByEqual()
+        {
+            var encrypted = EncryptedHostAssignmentContext.Create(_context, _encryptionKey);
+            var decrypted = encrypted.Decrypt(_encryptionKey);
+            Assert.True(_context.Equals(decrypted));
+        }
+
+        [Fact]
+        public void DecryptedContextShouldMatchEnvironments()
+        {
+            var encrypted = EncryptedHostAssignmentContext.Create(_context, _encryptionKey);
+            var decrypted = encrypted.Decrypt(_encryptionKey);
+            Assert.Equal(_context.Environment, decrypted.Environment);
+        }
+    }
+}

--- a/Kudu.Tests/TestHelpers.cs
+++ b/Kudu.Tests/TestHelpers.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kudu.Tests
+{
+    public static class TestHelpers
+    {
+        private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private static readonly Random Random = new Random();
+
+        public static byte[] GenerateKeyBytes()
+        {
+            using (var aes = new AesManaged())
+            {
+                aes.GenerateKey();
+                return aes.Key;
+            }
+        }
+
+        public static string GenerateKeyHexString(byte[] key = null)
+        {
+            return BitConverter.ToString(key ?? GenerateKeyBytes()).Replace("-", string.Empty);
+        }
+    }
+}

--- a/Kudu.sln
+++ b/Kudu.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kudu.Services.Web", "Kudu.S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kudu.Console", "Kudu.Console\Kudu.Console.csproj", "{32AE9472-F7C0-4ED8-8D8C-EAB2419F5083}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kudu.Tests", "Kudu.Tests\Kudu.Tests.csproj", "{C667BB81-BD51-4009-9555-1BC7462855B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{32AE9472-F7C0-4ED8-8D8C-EAB2419F5083}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{32AE9472-F7C0-4ED8-8D8C-EAB2419F5083}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32AE9472-F7C0-4ED8-8D8C-EAB2419F5083}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C667BB81-BD51-4009-9555-1BC7462855B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C667BB81-BD51-4009-9555-1BC7462855B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C667BB81-BD51-4009-9555-1BC7462855B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C667BB81-BD51-4009-9555-1BC7462855B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Background
The request is used by Linux Consumption functionapp server-side-build project. The project requires KuduLite to run on Service Fabric Mesh.

When deploying KuduLite in a Service Fabric Mesh container, KuduLite will receive an encrypted AppSettings context, we want KuduLite to decrypt the context and finish the initialization process.

### Pull Request Overview
1. Introduce WEBSITE_AUTH_ENCRYPTION_KEY. This is used for generating an authentication token. The token is required when sending request to Antares Frontend.
2. Introduce Decrypt() function. This function can decrypt the HostAssignment context during the container assignment process.
3. Introduce HostAssignment context. It contains the basic information of the SCM site (e.g. site name, environment variables).

Code Review Request: @sanchitmehta @JennyLawrance @ankitkumarr @maiqbal11