### PR TITLE
[functionapp] Add admin/instance/assign and admin/instance/info endpoints

### DIFF
--- a/Kudu.Contracts/ILinuxConsumptionEnvironment.cs
+++ b/Kudu.Contracts/ILinuxConsumptionEnvironment.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+
+namespace Kudu.Contracts
+{
+    public interface ILinuxConsumptionEnvironment
+    {
+        /// <summary>
+        /// Gets a value indicating whether requests should be delayed.
+        /// </summary>
+        bool DelayRequestsEnabled { get; }
+
+        Task DelayCompletionTask { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current environment is in standby mode.
+        /// </summary>
+        bool InStandbyMode { get; }
+
+        /// <summary>
+        /// Flags that requests under this environment should be delayed.
+        /// </summary>
+        void DelayRequests();
+
+        /// <summary>
+        /// Flags that requests under this environment should be resumed.
+        /// </summary>
+        void ResumeRequests();
+
+        /// <summary>
+        /// Flags the current environment as ready and specialized.
+        /// This sets <see cref="EnvironmentSettingNames.AzureWebsitePlaceholderMode"/> to "0"
+        /// and <see cref="EnvironmentSettingNames.AzureWebsiteContainerReady"/> to "1" against
+        /// the current environment.
+        /// </summary>
+        void FlagAsSpecializedAndReady();
+    }
+}

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -47,6 +47,8 @@
         public const string RunFromZip = "WEBSITE_RUN_FROM_PACKAGE";
         public const string MaxZipPackageCount = "SCM_MAX_ZIP_PACKAGE_COUNT";
         // Antares container specific settings
+        public const string PlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
+        public const string ContainerReady = "WEBSITE_CONTAINER_READY";
         public const string AuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
     }

--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -4,6 +4,8 @@ namespace Kudu.Core.Deployment.Oryx
 {
     internal static class OryxBuildConstants
     {
+        internal static readonly string EnableOryxBuild = "ENABLE_ORYX_BUILD";
+
         internal static class OryxEnvVars
         {
             public static readonly string FrameworkSetting = "FRAMEWORK";

--- a/Kudu.Core/Helpers/FunctionAppSpecializationHelper.cs
+++ b/Kudu.Core/Helpers/FunctionAppSpecializationHelper.cs
@@ -1,0 +1,41 @@
+﻿using Kudu.Contracts.Settings;
+using Kudu.Core.Deployment.Oryx;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kudu.Core.Helpers
+{
+    /// <summary>
+    /// Handle Function App container specialization when running in Service Fabric Mesh
+    /// </summary>
+    public static class FunctionAppSpecializationHelper
+    {
+        /// <summary>
+        /// According to the existing environment variables key-value pair, change the container environment.
+        /// </summary>
+        /// <param name="envKey">The key of environment variable</param>
+        /// <param name="envValue">The value of environment variable</param>
+        /// <returns>The new environment variables should be set</returns>
+        public static Dictionary<string, string> HandleLinuxConsumption(string envKey, string envValue)
+        {
+            Dictionary<string, string> toBeUpdatedEnv = new Dictionary<string, string>();
+            if (envKey == OryxBuildConstants.FunctionAppEnvVars.WorkerRuntimeSetting)
+            {
+                HandleFunctionWorkerRuntime(toBeUpdatedEnv, envValue);
+            }
+            return toBeUpdatedEnv;
+        }
+
+        private static void HandleFunctionWorkerRuntime(IDictionary<string, string> result, string workerRuntime)
+        {
+            if (workerRuntime == "python")
+            {
+                result.Add(SettingsKeys.DoBuildDuringDeployment, "true");
+                result.Add(OryxBuildConstants.EnableOryxBuild, "true");
+                result.Add(OryxBuildConstants.OryxEnvVars.FrameworkSetting, "PYTHON");
+                result.Add(OryxBuildConstants.OryxEnvVars.FrameworkVersionSetting, "3.6");
+            }
+        }
+    }
+}

--- a/Kudu.Core/LinuxConsumptionEnvironment.cs
+++ b/Kudu.Core/LinuxConsumptionEnvironment.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Kudu.Contracts;
+using Kudu.Contracts.Settings;
+
+namespace Kudu.Core
+{
+    public class LinuxConsumptionEnvironment : ILinuxConsumptionEnvironment
+    {
+        private readonly ReaderWriterLockSlim _delayLock = new ReaderWriterLockSlim();
+        private TaskCompletionSource<object> _delayTaskCompletionSource;
+        private bool? _standbyMode;
+
+        public LinuxConsumptionEnvironment()
+        {
+            _delayTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _delayTaskCompletionSource.SetResult(null);
+        }
+
+        public bool DelayRequestsEnabled => !DelayCompletionTask.IsCompleted;
+
+        public Task DelayCompletionTask
+        {
+            get
+            {
+                _delayLock.EnterReadLock();
+                try
+                {
+                    return _delayTaskCompletionSource.Task;
+                }
+                finally
+                {
+                    _delayLock.ExitReadLock();
+                }
+            }
+        }
+
+        public bool InStandbyMode
+        {
+            get
+            {
+                // once set, never reset
+                if (_standbyMode != null)
+                {
+                    return _standbyMode.Value;
+                }
+                if (IsPlaceHolderModeEnabled())
+                {
+                    return true;
+                }
+
+                // no longer standby mode
+                _standbyMode = false;
+
+                return _standbyMode.Value;
+            }
+        }
+
+        Task ILinuxConsumptionEnvironment.DelayCompletionTask => throw new NotImplementedException();
+
+        public void DelayRequests()
+        {
+            _delayLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (_delayTaskCompletionSource.Task.IsCompleted)
+                {
+                    _delayLock.EnterWriteLock();
+                    try
+                    {
+                        _delayTaskCompletionSource = new TaskCompletionSource<object>();
+                    }
+                    finally
+                    {
+                        _delayLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                _delayLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public void ResumeRequests()
+        {
+            _delayLock.EnterReadLock();
+            try
+            {
+                _delayTaskCompletionSource?.SetResult(null);
+            }
+            finally
+            {
+                _delayLock.ExitReadLock();
+            }
+        }
+
+        public void FlagAsSpecializedAndReady()
+        {
+            System.Environment.SetEnvironmentVariable(SettingsKeys.PlaceholderMode, "0");
+            System.Environment.SetEnvironmentVariable(SettingsKeys.ContainerReady, "1");
+        }
+
+        private bool IsPlaceHolderModeEnabled()
+        {
+            // If WEBSITE_PLACEHOLDER_MODE is not set, we consider the container as a placeholder
+            string placeHolderMode = System.Environment.GetEnvironmentVariable(SettingsKeys.PlaceholderMode);
+            return placeHolderMode == "1" || string.IsNullOrEmpty(placeHolderMode);
+        }
+    }
+}

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http.Formatting;
 using System.Reflection;
 using AspNetCore.RouteAnalyzer;
+using Kudu.Contracts;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.SourceControl;
@@ -25,6 +26,7 @@ using Kudu.Services.Performance;
 using Kudu.Services.TunnelServer;
 using Kudu.Services.Web.Infrastructure;
 using Kudu.Services.Web.Tracing;
+using Kudu.Services.LinuxConsumptionInstanceAdmin;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -120,6 +122,8 @@ namespace Kudu.Services.Web
                 });
 
             services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+            services.AddSingleton<ILinuxConsumptionEnvironment, LinuxConsumptionEnvironment>();
+            services.AddSingleton<ILinuxConsumptionInstanceManager, LinuxConsumptionInstanceManager>();
 
             KuduWebUtil.EnsureHomeEnvironmentVariable();
 

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/ILinuxConsumptionInstanceManager.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/ILinuxConsumptionInstanceManager.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Kudu.Services.Models;
+
+namespace Kudu.Services.LinuxConsumptionInstanceAdmin
+{
+    /// <summary>
+    /// Instance manager interface for modifying the behaviour in current instance
+    /// </summary>
+    public interface ILinuxConsumptionInstanceManager
+    {
+        /// <summary>
+        /// Get an overview information of current instance health status
+        /// </summary>
+        /// <returns></returns>
+        IDictionary<string, string> GetInstanceInfo();
+
+        /// <summary>
+        /// Validate if the assignment context matches the requirement for current instance's specialization
+        /// </summary>
+        /// <param name="assignmentContext">Contains site information such as environment variables</param>
+        /// <returns>Message on error, otherwise, null.</returns>
+        Task<string> ValidateContext(HostAssignmentContext assignmentContext);
+
+        /// <summary>
+        /// Apply assignment context and start specialization for current instance
+        /// </summary>
+        /// <param name="assignmentContext">Contains site information such as environment variables</param>
+        /// <returns>True on success.</returns>
+        bool StartAssignment(HostAssignmentContext assignmentContext);
+    }
+}

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
@@ -1,9 +1,10 @@
-﻿using Kudu.Services.Models;
+using Kudu.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Kudu.Contracts.Settings;
+using Kudu.Core.Helpers;
 using System.Collections.Generic;
 using Kudu.Services.Infrastructure.Authorization;
 
@@ -15,33 +16,36 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
     /// </summary>
     public class LinuxConsumptionInstanceAdminController : Controller
     {
+        private const string _appsettingPrefix = "APPSETTING_";
+        private readonly ILinuxConsumptionInstanceManager _instanceManager;
         private readonly IDeploymentSettingsManager _settingsManager;
 
         /// <summary>
         /// This class handles appsetting assignment and provide information when running in a Service Fabric Mesh container,
         /// namely, Functionapp on Linux Consumption Plan.
         /// </summary>
+        /// <param name="instanceManager">Allow KuduLite to interact with Service Fabric Mesh instance in Linux Consumption</param>
         /// <param name="settingsManager">Allow instance assignment to change application setting</param>
-        public LinuxConsumptionInstanceAdminController(IDeploymentSettingsManager settingsManager)
+        public LinuxConsumptionInstanceAdminController(ILinuxConsumptionInstanceManager instanceManager, IDeploymentSettingsManager settingsManager)
         {
+            _instanceManager = instanceManager;
             _settingsManager = settingsManager;
         }
 
         /// <summary>
-        /// A healthcheck endpoint which will be call after the container is established.
-        /// This endpoint is accessible by Antares DataRole only. KuduLite users are prohibited.
+        /// A healthcheck endpoint
         /// </summary>
         /// <returns>Expect 200 when current service is up and running</returns>
         [HttpGet]
         [Authorize(Policy = AuthPolicyNames.AdminAuthLevel)]
         public IActionResult Info()
         {
-            return Ok("Endpoint is not implemented");
+            return Ok(_instanceManager.GetInstanceInfo());
         }
 
         /// <summary>
-        /// A specialization endpoint. It sets the current service's site name, site id and environment variables.
-        /// This endpoint is accessible by Antares DataRole only. KuduLite users are prohibited.
+        /// A specialization endpoint.
+        /// It sets the current service's site name, site id and environment variables when it is called.
         /// </summary>
         /// <param name="encryptedAssignmentContext">Encrypted content which contains HostAssignmentContext</param>
         /// <returns>Expect 202 when receives the first call, otherwise, returns 409</returns>
@@ -49,7 +53,47 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
         [Authorize(Policy = AuthPolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> AssignAsync([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
         {
-            return Accepted("Endpoint is not implemented");
+            var containerKey = System.Environment.GetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey);
+            var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);
+
+            // before starting the assignment we want to perform as much
+            // up front validation on the context as possible
+            string error = await _instanceManager.ValidateContext(assignmentContext);
+            if (error != null)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest, error);
+            }
+
+            var assignmentResult = _instanceManager.StartAssignment(assignmentContext);
+
+            // modify app settings from environment variables (for all start with "APPSETTING_")
+            // setting APPSETTING_FUNCTIONS_EXTENSION_VERSION will both set the appsetting and environment variable
+            if (assignmentResult)
+            {
+                foreach (KeyValuePair<string, string> env in assignmentContext.Environment)
+                {
+                    string key = env.Key;
+                    string value = env.Value;
+
+                    if (key.StartsWith(_appsettingPrefix))
+                    {
+                        key = key.Substring(_appsettingPrefix.Length);
+                        _settingsManager.SetValue(key, value);
+                    }
+
+                    // configure function app specialization properly for Linux Consumption plan
+                    Dictionary<string, string> newSettings = FunctionAppSpecializationHelper.HandleLinuxConsumption(key, value);
+                    foreach (KeyValuePair<string, string> newSetting in newSettings)
+                    {
+                        System.Environment.SetEnvironmentVariable(newSetting.Key, newSetting.Value);
+                        _settingsManager.SetValue(newSetting.Key, newSetting.Value);
+                    }
+                }
+            }
+
+            return assignmentResult
+               ? Accepted()
+               : StatusCode(StatusCodes.Status409Conflict, "Instance already assigned");
         }
     }
 }

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceManager.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceManager.cs
@@ -1,0 +1,137 @@
+﻿using Kudu.Contracts;
+using Kudu.Services.Models;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kudu.Core.Infrastructure;
+
+namespace Kudu.Services.LinuxConsumptionInstanceAdmin
+{
+    /// <summary>
+    /// Used for configuring KuduLite instance when it is running in Linux Consumption Service Fabric Mesh
+    /// </summary>
+    public class LinuxConsumptionInstanceManager : ILinuxConsumptionInstanceManager
+    {
+        private static readonly object _assignmentLock = new object();
+        private static HostAssignmentContext _assignmentContext;
+
+        private readonly ILinuxConsumptionEnvironment _linuxConsumptionEnv;
+        private readonly HttpClient _client;
+
+        /// <summary>
+        /// Create a manager to specialize KuduLite when it is running in Service Fabric Mesh
+        /// </summary>
+        /// <param name="linuxConsumptionEnv">Environment variables</param>
+        public LinuxConsumptionInstanceManager(ILinuxConsumptionEnvironment linuxConsumptionEnv)
+        {
+            _linuxConsumptionEnv = linuxConsumptionEnv;
+            _client = new HttpClient();
+        }
+
+        public IDictionary<string, string> GetInstanceInfo()
+        {
+            var result = new Dictionary<string, string>();
+            foreach (DictionaryEntry entry in System.Environment.GetEnvironmentVariables())
+            {
+                result.Add((string)entry.Key, (string)entry.Value);
+            }
+            return result;
+        }
+
+        public bool StartAssignment(HostAssignmentContext context)
+        {
+            if (!_linuxConsumptionEnv.InStandbyMode)
+            {
+                return false;
+            }
+
+            if (_assignmentContext == null)
+            {
+                lock (_assignmentLock)
+                {
+                    if (_assignmentContext != null)
+                    {
+                        return _assignmentContext.Equals(context);
+                    }
+                    _assignmentContext = context;
+                }
+
+                // set a flag which will cause any incoming http requests to buffer
+                // until specialization is complete
+                // the host is guaranteed not to receive any requests until AFTER assign
+                // has been initiated, so setting this flag here is sufficient to ensure
+                // that any subsequent incoming requests while the assign is in progress
+                // will be delayed until complete
+                _linuxConsumptionEnv.DelayRequests();
+
+                // start the specialization process in the background
+                Task.Run(async () => await Assign(context));
+
+                return true;
+            }
+            else
+            {
+                // No lock needed here since _assignmentContext is not null when we are here
+                return _assignmentContext.Equals(context);
+            }
+        }
+
+        public async Task<string> ValidateContext(HostAssignmentContext assignmentContext)
+        {
+            string error = null;
+            HttpResponseMessage response = null;
+            try
+            {
+                var zipUrl = assignmentContext.ZipUrl;
+                if (!string.IsNullOrEmpty(zipUrl))
+                {
+                    // make sure the zip uri is valid and accessible
+                    await OperationManager.AttemptAsync(async () =>
+                    {
+                        try
+                        {
+                            var request = new HttpRequestMessage(HttpMethod.Head, zipUrl);
+                            response = await _client.SendAsync(request);
+                            response.EnsureSuccessStatusCode();
+                        }
+                        catch (Exception)
+                        {
+                            throw;
+                        }
+                    }, retries: 2, delayBeforeRetry: 300 /*ms*/);
+                }
+            }
+            catch (Exception)
+            {
+                error = $"Invalid zip url specified (StatusCode: {response?.StatusCode})";
+            }
+
+            return error;
+        }
+
+        private async Task Assign(HostAssignmentContext assignmentContext)
+        {
+            try
+            {
+                // first make all environment and file system changes required for
+                // the host to be specialized
+                assignmentContext.ApplyAppSettings();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                // all assignment settings/files have been applied so we can flip
+                // the switch now on specialization
+                // even if there are failures applying context above, we want to
+                // leave placeholder mode
+                _linuxConsumptionEnv.FlagAsSpecializedAndReady();
+                _linuxConsumptionEnv.ResumeRequests();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Dependency
https://github.com/Azure-App-Service/KuduLite/pull/42

### Background
In order to make KuduLite running in Service Fabric Mesh container, during the initialization phrase, Datarole will make a call to **admin/instance/assign** and **admin/instance/info**.

**admin/instance/assign** endpoint will acknowledge KuduLite with site name, assign environment variables to the container.

**admin/instance/info** endpoint is used for health check when running in Service Fabric Mesh.

### Overview
1. The **admin/instance/assign** endpoint will set the environment variables for Service Fabric Mesh container. The variables with "APPSETTING_" prefix will be propagated to application settings.
2. The **admin/instance/info** endpoint will return all environment variables.

### Discussion
Previously, we have discussed on whether it is feasible to add these two endpoints. (@maiqbal11, @anirudhgarg, @sanchitmehta and @rramachand21). Since the PR is out currently (with https://github.com/Azure-App-Service/KuduLite/pull/42), I think we may sit down decide if we want to merge in these changes.