### PR TITLE
[functionapp] Add SCM url sanitizer when running in Linux Consumption SeaBreeze

### DIFF
--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -363,7 +363,7 @@ namespace Kudu.Core
 
                 // GetLeftPart(Authority) returns the https://www.example.com of any Uri
                 var displayUrl = _httpContextAccessor?.HttpContext?.Request?.GetDisplayUrl();
-                var url = displayUrl == null ? null : new Uri(displayUrl).GetLeftPart(UriPartial.Authority);
+                var url = displayUrl == null ? null : new Uri(ScmSiteUrlHelper.SanitizeUrl(displayUrl)).GetLeftPart(UriPartial.Authority);
                 if (string.IsNullOrEmpty(url))
                 {
                     // if call is not done in Request context (eg. in BGThread), fall back to %host%

--- a/Kudu.Core/Helpers/ScmSiteUrlHelper.cs
+++ b/Kudu.Core/Helpers/ScmSiteUrlHelper.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Kudu.Core.Helpers
+{
+    public class ScmSiteUrlHelper
+    {
+        private static Regex malformedScmHostnameRx = new Regex(@"://~\d+");
+
+        /// <summary>
+        /// Remove the ~[number] in http url
+        /// </summary>
+        /// <param name="scmUrl">An scm site url (e.g. http://~1linuxfunctiondev-funnystamp-func/)</param>
+        /// <returns>A url without ~1, (e.g. http://linuxfunctiondev-funnystamp-func/) </returns>
+        public static string SanitizeUrl(string scmUrl)
+        {
+            if (string.IsNullOrEmpty(scmUrl))
+            {
+                return scmUrl;
+            }
+
+            return malformedScmHostnameRx.Replace(scmUrl, @"://", 1);
+        }
+    }
+}

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -12,6 +12,7 @@ using Kudu.Core.Tracing;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Kudu.Core.Helpers;
 
 namespace Kudu.Core.Jobs
 {
@@ -521,7 +522,7 @@ namespace Kudu.Core.Jobs
                     return _lastKnownAppBaseUrlPrefix;
                 }
 
-                var requestUrl = new Uri(context.Request.GetDisplayUrl());
+                var requestUrl = new Uri(ScmSiteUrlHelper.SanitizeUrl(context.Request.GetDisplayUrl()));
 
                 _lastKnownAppBaseUrlPrefix = requestUrl.GetLeftPart(UriPartial.Authority);
                 return _lastKnownAppBaseUrlPrefix;

--- a/Kudu.Core/Tracing/TraceExtensions.cs
+++ b/Kudu.Core/Tracing/TraceExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Primitives;
@@ -155,7 +156,7 @@ namespace Kudu.Core.Tracing
                 return true;
             }
 
-            return !String.Equals(new Uri(request.GetDisplayUrl()).Host, refererUri.Host, StringComparison.OrdinalIgnoreCase);
+            return !String.Equals(new Uri(ScmSiteUrlHelper.SanitizeUrl(request.GetDisplayUrl())).Host, refererUri.Host, StringComparison.OrdinalIgnoreCase);
         }
 
         private static TraceLevel GetTraceLevel(IDictionary<string, string> attributes)

--- a/Kudu.Services.Web/Tracing/TraceMiddleware.cs
+++ b/Kudu.Services.Web/Tracing/TraceMiddleware.cs
@@ -240,13 +240,13 @@ namespace Kudu.Services.Web.Tracing
 
         private static string GetRawUrl(HttpRequest request)
         {
-            var uri = new Uri(request.GetDisplayUrl());
+            var uri = new Uri(request.GetSanitizedDisplayUrl());
             return uri.PathAndQuery;
         }
 
         private static string GetHostUrl(HttpRequest request)
         {
-            var uri = new Uri(request.GetDisplayUrl());
+            var uri = new Uri(request.GetSanitizedDisplayUrl());
             return uri.Host;
         }
 

--- a/Kudu.Services/Arm/ArmUtils.cs
+++ b/Kudu.Services/Arm/ArmUtils.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using Kudu.Contracts.Infrastructure;
+using Kudu.Services.Infrastructure;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -64,7 +65,7 @@ namespace Kudu.Services.Arm
             // In Azure ARM requests, the referrer is the current id
             //Uri referrer = request.Headers.Referrer;
             Uri referrer = new Uri(request.Headers["Referer"].ToString()); // NOT MISSPELLED, https://en.wikipedia.org/wiki/HTTP_referer
-            armEntry.Id = referrer != null ? referrer.AbsolutePath : new Uri(request.GetDisplayUrl()).AbsolutePath;
+            armEntry.Id = referrer != null ? referrer.AbsolutePath : new Uri(request.GetSanitizedDisplayUrl()).AbsolutePath;
 
             // If we're generating a child object, append the child name
             if (isChild)

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -145,7 +145,7 @@ namespace Kudu.Services.Deployment
 
                                     // e.g if final url is "https://kudutry.scm.azurewebsites.net/api/deployments/ef52ec67fc9574e726955a9cbaf7bcba791e4e95/log"
                                     // deploymentUri should be "https://kudutry.scm.azurewebsites.net/api/deployments/ef52ec67fc9574e726955a9cbaf7bcba791e4e95"
-                                    Uri deploymentUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetDisplayUrl()).AbsolutePath);
+                                    Uri deploymentUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetSanitizedDisplayUrl()).AbsolutePath);
                                     deployResult.Url = deploymentUri;
                                     deployResult.LogUrl = kUriHelper.MakeRelative(deploymentUri, "log");
 
@@ -427,7 +427,7 @@ namespace Kudu.Services.Deployment
                     foreach (var entry in deployments)
                     {
                         if (!entry.HasDetails) continue;
-                        Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetDisplayUrl()).AbsolutePath);
+                        Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetSanitizedDisplayUrl()).AbsolutePath);
                         entry.DetailsUrl = kUriHelper.MakeRelative(baseUri, entry.Id);
                     }
 
@@ -481,7 +481,7 @@ namespace Kudu.Services.Deployment
                 DeployResult pending;
                 if (IsLatestPendingDeployment(ref id, out pending))
                 {
-                    Response.GetTypedHeaders().Location = new Uri(Request.GetDisplayUrl());
+                    Response.GetTypedHeaders().Location = new Uri(Request.GetSanitizedDisplayUrl());
                     return Accepted(ArmUtils.AddEnvelopeOnArmRequest(pending, Request));
                 }
 
@@ -494,7 +494,7 @@ namespace Kudu.Services.Deployment
                                                                        id));
                 }
 
-                Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetDisplayUrl()).AbsolutePath);
+                Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(Request), new Uri(Request.GetSanitizedDisplayUrl()).AbsolutePath);
                 result.Url = baseUri;
                 result.LogUrl = kUriHelper.MakeRelative(baseUri, "log");
 
@@ -579,7 +579,7 @@ namespace Kudu.Services.Deployment
 
         private EntityTagHeaderValue GetCurrentEtag(HttpRequest request)
         {
-            return new EntityTagHeaderValue(String.Format("\"{0:x}\"", new Uri(request.GetDisplayUrl()).PathAndQuery.GetHashCode() ^ _status.LastModifiedTime.Ticks));
+            return new EntityTagHeaderValue(String.Format("\"{0:x}\"", new Uri(request.GetSanitizedDisplayUrl()).PathAndQuery.GetHashCode() ^ _status.LastModifiedTime.Ticks));
         }
 
         private static bool EtagEquals(HttpRequest request, EntityTagHeaderValue currentEtag)
@@ -599,7 +599,7 @@ namespace Kudu.Services.Deployment
         {
             foreach (var result in _deploymentManager.GetResults())
             {
-                Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(request), new Uri(Request.GetDisplayUrl()).AbsolutePath);
+                Uri baseUri = kUriHelper.MakeRelative(kUriHelper.GetBaseUri(request), new Uri(Request.GetSanitizedDisplayUrl()).AbsolutePath);
                 result.Url = kUriHelper.MakeRelative(baseUri, result.Id);
                 result.LogUrl = kUriHelper.MakeRelative(baseUri, result.Id + "/log");
                 yield return result;

--- a/Kudu.Services/Infrastructure/HttpRequestExtensions.cs
+++ b/Kudu.Services/Infrastructure/HttpRequestExtensions.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Kudu.Core.Helpers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Kudu.Services.Infrastructure
 {
@@ -18,5 +20,15 @@ namespace Kudu.Services.Infrastructure
             return httpRequest.Headers["User-Agent"].ToString();
         }
 
+        /// <summary>
+        /// When the container running in SeaBreeze, the container will receive request with "http://~1sitename" in the url
+        /// We need to sanitize it otherwise it will break "new Uri(request.GetDisplayUrl())" call
+        /// </summary>
+        /// <param name="httpRequest">The http request from frontend</param>
+        /// <returns>A url without ~1</returns>
+        public static string GetSanitizedDisplayUrl(this HttpRequest httpRequest)
+        {
+            return ScmSiteUrlHelper.SanitizeUrl(httpRequest.GetDisplayUrl());
+        }
     }
 }

--- a/Kudu.Services/Infrastructure/UriHelper.cs
+++ b/Kudu.Services/Infrastructure/UriHelper.cs
@@ -33,7 +33,7 @@ namespace Kudu.Services.Infrastructure
 
         public static Uri GetRequestUri(HttpRequest request)
         {
-            return GetRequestUriInternal(new Uri(request.GetDisplayUrl()), request.Headers[DisguisedHostHeaderName]);
+            return GetRequestUriInternal(new Uri(request.GetSanitizedDisplayUrl()), request.Headers[DisguisedHostHeaderName]);
         }
 
         private static Uri GetRequestUriInternal(Uri uri, string disguisedHostValue)

--- a/Kudu.Services/SourceControl/LiveScmEditorController.cs
+++ b/Kudu.Services/SourceControl/LiveScmEditorController.cs
@@ -534,7 +534,7 @@ namespace Kudu.Services.SourceControl
             public QueryParameters(HttpRequest request)
             {
                 // CORE TODO make sure .Query has the same semantics as the old .QueryString (null, empty, etc.)
-                Message = request.Query["Message"].ToString() ?? String.Format("Committing update from request {0}", new Uri(request.GetDisplayUrl()).AbsolutePath);
+                Message = request.Query["Message"].ToString() ?? String.Format("Committing update from request {0}", new Uri(request.GetSanitizedDisplayUrl()).AbsolutePath);
                 NoDeploy = GetBooleanValue(request.Query["NoDeploy"].ToString());
             }
 

--- a/Kudu.Tests/Core/Helpers/ScmSiteUrlHelperTests.cs
+++ b/Kudu.Tests/Core/Helpers/ScmSiteUrlHelperTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Kudu.Core.Helpers;
+
+namespace Kudu.Tests.Core.Helpers
+{
+    public class ScmSiteUrlHelperTests
+    {
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("https://azurewebsites.net", "https://azurewebsites.net")]
+        [InlineData("https://functions.azurewebsites.net", "https://functions.azurewebsites.net")]
+        [InlineData("https://~1functions.azurewebsites.net", "https://functions.azurewebsites.net")]
+        [InlineData("https://~12functions.azurewebsites.net", "https://functions.azurewebsites.net")]
+        [InlineData("https://~123functions.azurewebsites.net/api", "https://functions.azurewebsites.net/api")]
+        [InlineData("ssh://~1234functions.azurewebsites.net/webssh", "ssh://functions.azurewebsites.net/webssh")]
+        [InlineData("https://123functions.azurewebsites.net/api", "https://123functions.azurewebsites.net/api")]
+        [InlineData("~functions.azurewebsites.net", "~functions.azurewebsites.net")]
+        [InlineData("/api/HttpTrigger", "/api/HttpTrigger")]
+        public void SanitizeUrlTest(string origin, string expected)
+        {
+            string result = ScmSiteUrlHelper.SanitizeUrl(origin);
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
The frontend will call the Scm site with **https://~1sitename.azurewebsites.net** in the Request Url.
This will often fail the upcoming **new Uri()* call.

The **new Uri(Request.GetDisplayUrl())** pattern has occurred so many times in the code base.

Currently, such issue has been handled inconsistently (e.g. Kudu.Services.Web\Tracing\TraceMiddleware.cs:375).
We want to give a more general fix. I tried to fix it in **Environment.cs AppBaseUrlPrefix**, but such issue covers more places than expected.

If there is a better idea how to do it in a cleaner way, please let me know.

Code Review Request: @sanchitmehta