### PR TITLE
[Fix] Remove duplicated volatileLogsPath definitions

### DIFF
--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -48,8 +48,6 @@ namespace Kudu.Services.Performance
 
         private const string volatileLogsPath = "/appsvctmp/volatile/logs/runtime";
 
-        private const string volatileLogsPath = "/appsvctmp/volatile/logs/runtime";
-
         // CORE TODO
         //private ShutdownDetector _shutdownDetector;
         //private CancellationTokenRegistration _cancellationTokenRegistration;


### PR DESCRIPTION
This volatileLogsPath is defined twice in **Kudu.Services/Diagnostics/LogStreamManager.cs**

The issue only occurs in **dev** branch.