### PR TITLE
[functionapp] Add ?dobuild= query param option in /api/zipdeploy

### DIFF
--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -28,6 +28,10 @@ namespace Kudu.Core.Deployment
         public FetchDelegate Fetch { get; set; }
         public bool AllowDeploymentWhileScmDisabled { get; set; }
 
+        // If this value is set true/false, will override SCM_DO_BUILD_DURING_DEPLOYMENT
+        // If it is null, will obey the setting in SCM_DO_BUILD_DURING_DEPLOYMENT
+        public bool? ForceBuild { get; set; }
+
         // Optional.
         // Path of the directory to be deployed to. The path should be relative to the wwwroot directory.
         // Example: "webapps/ROOT"

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.SourceControl;
+using Kudu.Core.Deployment;
 
 namespace Kudu.Contracts.Settings
 {

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -612,7 +612,7 @@ namespace Kudu.Core.Deployment
                 {
                     using (tracer.Step("Determining deployment builder"))
                     {
-                        builder = _builderFactory.CreateBuilder(tracer, innerLogger, perDeploymentSettings, repository);
+                        builder = _builderFactory.CreateBuilder(tracer, innerLogger, perDeploymentSettings, repository, deploymentInfo.ForceBuild);
                         deploymentAnalytics.ProjectType = builder.ProjectType;
                         tracer.Trace("Builder is {0}", builder.GetType().Name);
                     }

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -22,7 +22,7 @@ namespace Kudu.Core.Deployment.Generator
             _environment = environment;
         }
 
-        public ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository repository)
+        public ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository repository, bool? isForcedBuild)
         {
             string repositoryRoot = repository.RepositoryPath;
 
@@ -57,7 +57,7 @@ namespace Kudu.Core.Deployment.Generator
                 return new RunFromZipSiteBuilder();
             }
             
-            if (!settings.DoBuildDuringDeployment())
+            if (isForcedBuild ?? !settings.DoBuildDuringDeployment())
             {
                 var projectPath = !String.IsNullOrEmpty(targetProjectPath) ? targetProjectPath : repositoryRoot;
                 return new BasicBuilder(_environment, settings, _propertyProvider, repositoryRoot, projectPath);

--- a/Kudu.Core/Deployment/ISiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/ISiteBuilderFactory.cs
@@ -6,6 +6,6 @@ namespace Kudu.Core.Deployment
 {
     public interface ISiteBuilderFactory
     {
-        ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository fileFinder);
+        ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository fileFinder, bool? isForcedBuild);
     }
 }

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -51,6 +51,7 @@ namespace Kudu.Services.Deployment
         [DisableFormValueModelBinding]
         public async Task<IActionResult> ZipPushDeploy(
             [FromQuery] bool isAsync = false,
+            [FromQuery] bool? doBuild = null,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -74,7 +75,8 @@ namespace Kudu.Services.Deployment
                     Author = author,
                     AuthorEmail = authorEmail,
                     Message = message,
-                    ZipURL = null
+                    ZipURL = null,
+                    ForceBuild = doBuild,
                 };
 
                 if (_settings.RunFromLocalZip())
@@ -99,6 +101,7 @@ namespace Kudu.Services.Deployment
         public async Task<IActionResult> ZipPushDeployViaUrl(
             [FromBody] JObject requestJson,
             [FromQuery] bool isAsync = false,
+            [FromQuery] bool? doBuild = null,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -125,6 +128,7 @@ namespace Kudu.Services.Deployment
                     AuthorEmail = authorEmail,
                     Message = message,
                     ZipURL = zipUrl,
+                    ForceBuild = doBuild,
                 };
                 return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
             }


### PR DESCRIPTION
### Backgrounds
In function core tools, we want to introduce an option for user to **overwrite the build behavior for a specific deployment**.

For example:
`func azure functionapp publish --build-on-deployment [true|false]`

In this case, if a user specified the **--build-on-deployment true** behavior, we will shadow the **SCM_DO_BUILD_DURING_DEPLOYMENT** setting for once. The function core tool call the **/api/zipdeploy** endpoint with **?doBuild=true** query parameter.

Generally speaking, **SCM_DO_BUILD_DURING_DEPLOYMENT** is the default behavior when publishing a function, but if **?doBuild=** is specified, **?doBuild=** will take precedence.

### Truth Table

SCM_DO_BUILD_DURING_DEPLOYMENT   (default: False) | --build-on-deployment   (default: Null) | ?dobuild=   (default: Not Set) | Do Build
-- | -- | -- | --
 False | False | False | No
 False | True | True | Yes
 True | False | False | No
 True | True | True | Yes
 False | Null | Not Set | No
 False | Null | Not Set | No
 True | Null | Not Set | Yes
 True | Null | Not Set | Yes

### Code Review and Discussion
@sanchitmehta @ankitkumarr @ColbyTresness