### PR TITLE
[functionapp] Implement authentication for Linux Consumption endpoints

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -105,6 +105,8 @@ namespace Kudu
         public const string SiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string HttpHost = "HTTP_HOST";
         public const string WebSiteSwapSlotName = "WEBSITE_SWAP_SLOTNAME";
+        public const string AzureWebsiteInstanceId = "WEBSITE_INSTANCE_ID";
+        public const string ContainerName = "CONTAINER_NAME";
 
         public const string Function = "function";
         public const string Functions = "functions";

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -30,5 +30,6 @@
         string RequestId { get; }               // e.g. x-arr-log-id or x-ms-request-id header value
         string KuduConsoleFullPath { get; }     // e.g. KuduConsole/kudu.dll
         string SitePackagesPath { get; }        // e.g. /data/SitePackages
+        bool IsOnLinuxConsumption { get; }      // e.g. True on Linux Consumption. False on App Service.
     }
 }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -385,6 +385,15 @@ namespace Kudu.Core
             private set;
         }
 
+        public bool IsOnLinuxConsumption
+        {
+            get {
+                bool isOnAppService = !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.AzureWebsiteInstanceId));
+                bool isOnLinuxContainer = !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.ContainerName));
+                return isOnLinuxContainer && !isOnAppService;
+            }
+        }
+
         public string KuduConsoleFullPath { get; }
 
         public static bool IsAzureEnvironment()

--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -527,11 +527,11 @@ namespace Kudu.Services.Web
         /// </summary>
         /// <param name="services">Dependency injection to application service</param>
         /// <returns>Service</returns>
-        internal static IServiceCollection AddLinuxConsumptionAuthorization(this IServiceCollection services)
+        internal static IServiceCollection AddLinuxConsumptionAuthorization(this IServiceCollection services, IEnvironment environment)
         {
             services.AddAuthorization(o =>
             {
-                o.AddInstanceAdminPolicies();
+                o.AddInstanceAdminPolicies(environment);
             });
 
             services.AddSingleton<IAuthorizationHandler, AuthLevelAuthorizationHandler>();

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -93,11 +93,6 @@ namespace Kudu.Services.Web
                 .AddApplicationPart(kuduServicesAssembly).AddControllersAsServices()
                 .AddApiExplorer();
 
-            // Add middleware for Linux Consumption authentication and authorization
-            // when KuduLIte is running in service fabric mesh
-            services.AddLinuxConsumptionAuthentication();
-            services.AddLinuxConsumptionAuthorization(_webAppRuntimeEnvironment);
-
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info {Title = "Kudu API Docs"});
@@ -141,6 +136,11 @@ namespace Kudu.Services.Web
 
             // Add various folders that never change to the process path. All child processes will inherit this
             KuduWebUtil.PrependFoldersToPath(environment);
+
+            // Add middleware for Linux Consumption authentication and authorization
+            // when KuduLIte is running in service fabric mesh
+            services.AddLinuxConsumptionAuthentication();
+            services.AddLinuxConsumptionAuthorization(environment);
 
             // General
             services.AddSingleton<IServerConfiguration>(ServerConfiguration);

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -96,7 +96,7 @@ namespace Kudu.Services.Web
             // Add middleware for Linux Consumption authentication and authorization
             // when KuduLIte is running in service fabric mesh
             services.AddLinuxConsumptionAuthentication();
-            services.AddLinuxConsumptionAuthorization();
+            services.AddLinuxConsumptionAuthorization(_webAppRuntimeEnvironment);
 
             services.AddSwaggerGen(c =>
             {

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -29,6 +29,8 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Kudu.Services.Zip;
 using System.IO.Compression;
+using Microsoft.AspNetCore.Authorization;
+using Kudu.Services.Infrastructure.Authorization;
 
 namespace Kudu.Services.Deployment
 {
@@ -70,6 +72,7 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <param name="id">id of the deployment to delete</param>
         [HttpDelete]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult Delete(string id)
         {
             IActionResult result = Ok();
@@ -104,6 +107,7 @@ namespace Kudu.Services.Deployment
 
         
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult IsDeploying()
         {
             return Json(new Dictionary<string,bool>(){{"value" , _deploymentLock.IsHeld}});
@@ -115,6 +119,7 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <param name="id">id of the deployment to redeploy</param>
         [HttpPut]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> Deploy(string id = null)
         {
             JObject jsonContent = GetJsonContent();
@@ -368,6 +373,7 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetDeployResults()
         {
             IActionResult result;
@@ -417,6 +423,7 @@ namespace Kudu.Services.Deployment
         /// <param name="id">id of the deployment</param>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetLogEntry(string id)
         {
             using (_tracer.Step("DeploymentService.GetLogEntry"))
@@ -447,6 +454,7 @@ namespace Kudu.Services.Deployment
         /// <param name="logId">id of the log entry</param>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetLogEntryDetails(string id, string logId)
         {
             using (_tracer.Step("DeploymentService.GetLogEntryDetails"))
@@ -474,6 +482,7 @@ namespace Kudu.Services.Deployment
         /// <param name="id">id of the deployment</param>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetResult(string id)
         {
             using (_tracer.Step("DeploymentService.GetResult"))
@@ -540,6 +549,7 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetDeploymentScript()
         {
             using (_tracer.Step("DeploymentService.GetDeploymentScript"))

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -34,6 +34,7 @@ using Kudu.Services.Infrastructure.Authorization;
 
 namespace Kudu.Services.Deployment
 {
+    [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
     public class DeploymentController : Controller
     {
         private static DeploymentsCacheItem _cachedDeployments = DeploymentsCacheItem.None;
@@ -72,7 +73,6 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <param name="id">id of the deployment to delete</param>
         [HttpDelete]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult Delete(string id)
         {
             IActionResult result = Ok();
@@ -107,7 +107,6 @@ namespace Kudu.Services.Deployment
 
         
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult IsDeploying()
         {
             return Json(new Dictionary<string,bool>(){{"value" , _deploymentLock.IsHeld}});
@@ -119,7 +118,6 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <param name="id">id of the deployment to redeploy</param>
         [HttpPut]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> Deploy(string id = null)
         {
             JObject jsonContent = GetJsonContent();
@@ -373,7 +371,6 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetDeployResults()
         {
             IActionResult result;
@@ -423,7 +420,6 @@ namespace Kudu.Services.Deployment
         /// <param name="id">id of the deployment</param>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetLogEntry(string id)
         {
             using (_tracer.Step("DeploymentService.GetLogEntry"))
@@ -454,7 +450,6 @@ namespace Kudu.Services.Deployment
         /// <param name="logId">id of the log entry</param>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetLogEntryDetails(string id, string logId)
         {
             using (_tracer.Step("DeploymentService.GetLogEntryDetails"))
@@ -482,7 +477,6 @@ namespace Kudu.Services.Deployment
         /// <param name="id">id of the deployment</param>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetResult(string id)
         {
             using (_tracer.Step("DeploymentService.GetResult"))
@@ -549,7 +543,6 @@ namespace Kudu.Services.Deployment
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public IActionResult GetDeploymentScript()
         {
             using (_tracer.Step("DeploymentService.GetDeploymentScript"))

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -22,6 +22,7 @@ using Kudu.Services.Infrastructure.Authorization;
 
 namespace Kudu.Services.Deployment
 {
+    [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
     public class PushDeploymentController : Controller
     {
         private const string DefaultDeployer = "Push-Deployer";
@@ -51,7 +52,6 @@ namespace Kudu.Services.Deployment
         [HttpPost]
         [DisableRequestSizeLimit]
         [DisableFormValueModelBinding]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> ZipPushDeploy(
             [FromQuery] bool isAsync = false,
             [FromQuery] string author = null,
@@ -99,7 +99,6 @@ namespace Kudu.Services.Deployment
         }
 
         [HttpPut]
-        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> ZipPushDeployViaUrl(
             [FromBody] JObject requestJson,
             [FromQuery] bool isAsync = false,

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -17,6 +17,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
+using Kudu.Services.Infrastructure.Authorization;
 
 namespace Kudu.Services.Deployment
 {
@@ -49,6 +51,7 @@ namespace Kudu.Services.Deployment
         [HttpPost]
         [DisableRequestSizeLimit]
         [DisableFormValueModelBinding]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> ZipPushDeploy(
             [FromQuery] bool isAsync = false,
             [FromQuery] string author = null,
@@ -96,6 +99,7 @@ namespace Kudu.Services.Deployment
         }
 
         [HttpPut]
+        [Authorize(AuthPolicyNames.LinuxConsumptionRestriction)]
         public async Task<IActionResult> ZipPushDeployViaUrl(
             [FromBody] JObject requestJson,
             [FromQuery] bool isAsync = false,

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -48,8 +48,6 @@ namespace Kudu.Services.Performance
 
         private const string volatileLogsPath = "/appsvctmp/volatile/logs/runtime";
 
-        private const string volatileLogsPath = "/appsvctmp/volatile/logs/runtime";
-
         // CORE TODO
         //private ShutdownDetector _shutdownDetector;
         //private CancellationTokenRegistration _cancellationTokenRegistration;

--- a/Kudu.Services/Infrastructure/Authorization/AuthOptionsExtensions.cs
+++ b/Kudu.Services/Infrastructure/Authorization/AuthOptionsExtensions.cs
@@ -3,17 +3,31 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Kudu.Services.Infrastructure.Authentication;
+using Kudu.Core;
 
 namespace Kudu.Services.Infrastructure.Authorization
 {
     public static class AuthOptionsExtensions
     {
-        public static void AddInstanceAdminPolicies(this AuthorizationOptions options)
+        public static void AddInstanceAdminPolicies(this AuthorizationOptions options, IEnvironment environment)
         {
             options.AddPolicy(AuthPolicyNames.AdminAuthLevel, p =>
             {
                 p.AddInstanceAuthenticationSchemes();
                 p.AddRequirements(new AuthLevelRequirement(AuthorizationLevel.Admin));
+            });
+
+            options.AddPolicy(AuthPolicyNames.LinuxConsumptionRestriction, p =>
+            {
+                p.AddInstanceAuthenticationSchemes();
+                if (environment.IsOnLinuxConsumption)
+                {
+                    p.AddRequirements(new AuthLevelRequirement(AuthorizationLevel.Admin));
+                }
+                else
+                {
+                    p.AddRequirements(new AuthLevelRequirement(AuthorizationLevel.Anonymous));
+                }
             });
         }
 

--- a/Kudu.Services/Infrastructure/Authorization/AuthPolicyNames.cs
+++ b/Kudu.Services/Infrastructure/Authorization/AuthPolicyNames.cs
@@ -1,7 +1,19 @@
 ﻿namespace Kudu.Services.Infrastructure.Authorization
 {
+    /// <summary>
+    /// Authorization Policies that can be applied to the endpoints
+    /// </summary>
     public static class AuthPolicyNames
     {
+        /// <summary>
+        /// Only requests with "x-ms-site-restricted-token" can access the endpoint
+        /// </summary>
         public const string AdminAuthLevel = "AuthLevelAdmin";
+
+        /// <summary>
+        /// When running on Linux Consumption, only requests with "x-ms-site-restricted-token" can access the endpoint.
+        /// No restriction when running on App Service.
+        /// </summary>
+        public const string LinuxConsumptionRestriction = "LinuxConsumptionRestriction";
     }
 }

--- a/Kudu.Tests/Services/EnvironmentTests.cs
+++ b/Kudu.Tests/Services/EnvironmentTests.cs
@@ -1,0 +1,49 @@
+﻿using Kudu.Core;
+using Kudu.Services;
+using Kudu.Tests;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Kudu.Tests.Services
+{
+    public class EnvironmentTests
+    {
+        [Fact]
+        public void LinuxConsumptionPlan()
+        {
+            using(new TestScopedEnvironmentVariable("CONTAINER_NAME", "cn"))
+            {
+                IEnvironment env = TestMockedEnvironment.GetMockedEnvironment();
+                Assert.True(env.IsOnLinuxConsumption);
+            }
+        }
+
+        [Fact]
+        public void LinuxDedicatedPlan()
+        {
+            using (new TestScopedEnvironmentVariable("WEBSITE_INSTANCE_ID", "wii"))
+            {
+                IEnvironment env = TestMockedEnvironment.GetMockedEnvironment();
+                Assert.False(env.IsOnLinuxConsumption);
+            }
+        }
+
+        [Fact]
+        public void InvalidLinuxPlan()
+        {
+            using (new TestScopedEnvironmentVariable("CONTAINER_NAME", "cn"))
+            using (new TestScopedEnvironmentVariable("WEBSITE_INSTANCE_ID", "wii"))
+            {
+                IEnvironment env = TestMockedEnvironment.GetMockedEnvironment();
+                Assert.False(env.IsOnLinuxConsumption);
+            }
+        }
+
+        [Fact]
+        public void UnsetLinuxPlan()
+        {
+            IEnvironment env = TestMockedEnvironment.GetMockedEnvironment();
+            Assert.False(env.IsOnLinuxConsumption);
+        }
+    }
+}

--- a/Kudu.Tests/TestMockedEnvironment.cs
+++ b/Kudu.Tests/TestMockedEnvironment.cs
@@ -1,0 +1,13 @@
+﻿using Kudu.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace Kudu.Tests
+{
+    public class TestMockedEnvironment
+    {
+        public static IEnvironment GetMockedEnvironment(string rootPath = "rootPath", string binPath = "binPath", string repositoryPath = "repositoryPath", string requestId = "requestId", string kuduConsoleFullPath = "kuduConsoleFullPath")
+        {
+            return new Environment(rootPath, binPath, repositoryPath, requestId, kuduConsoleFullPath, new HttpContextAccessor());
+        }
+    }
+}


### PR DESCRIPTION
### Background
In Linux Consumption, the Repository container can be accessed by IP address. This introduces a security flaw because there's no frontend authentication guarding the KuduLite endpoints.

### Solution
We want to introduce an authorization mechanism to prevent anonymous user from using the KuduLite endpoints. We introduce a new authorization policy **LinuxConsumptionRestriction** which will apply admin auth requirements when KuduLite is running in Linux Consumption. It should check **x-ms-site-restricted-token** in request header when running in SeaBreeze.

Currently, we apply such authorization mechanism on **zipdeploy** and **deployment log** endpoints.

### Code Review Request
@balag0 @sanchitmehta @JennyLawrance 