### PR TITLE
Update Node default version

### DIFF
--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -20,7 +20,7 @@ namespace Kudu.Core.Deployment.Oryx
 
         internal static class FunctionAppWorkerRuntimeDefaults
         {
-            public static readonly string Node = "10.14.1";
+            public static readonly string Node = "8.15";
             public static readonly string Python = "3.6";
             public static readonly string Dotnet = "2.2";
         }


### PR DESCRIPTION
@sanchitmehta @JennyLawrance 

Oryx removed support for 10.14.1 in the latest build image. Also, it seems like in Linux Function App runtime, we currently use Node 8. It makes sense to build using that version.