### PR TITLE
[functionapp] Allow KuduLite to package functionapp into squashfs

### DIFF
--- a/Kudu.Core/Deployment/DeploymentHelper.cs
+++ b/Kudu.Core/Deployment/DeploymentHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Deployment.Oryx;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
@@ -52,13 +53,14 @@ namespace Kudu.Core.Deployment
             return false;
         }
         
-        public static void PurgeZipsIfNecessary(string sitePackagesPath, ITracer tracer, int totalAllowedZips)
+        public static void PurgeBuildArtifactsIfNecessary(string sitePackagesPath, BuildArtifactType fileExtension, ITracer tracer, int totalAllowedFiles)
         {
-            IEnumerable<string> zipFiles = FileSystemHelpers.GetFiles(sitePackagesPath, "*.zip");
-            if (zipFiles.Count() > totalAllowedZips)
+            string extension = fileExtension.ToString().ToLowerInvariant();
+            IEnumerable<string> fileNames = FileSystemHelpers.GetFiles(sitePackagesPath, $"*.{extension}");
+            if (fileNames.Count() > totalAllowedFiles)
             {
                 // Order the files in descending order of the modified date and remove the last (N - allowed zip files).
-                var fileNamesToDelete = zipFiles.OrderByDescending(fileName => FileSystemHelpers.GetLastWriteTimeUtc(fileName)).Skip(totalAllowedZips);
+                var fileNamesToDelete = fileNames.OrderByDescending(fileName => FileSystemHelpers.GetLastWriteTimeUtc(fileName)).Skip(totalAllowedFiles);
                 foreach (var fileName in fileNamesToDelete)
                 {
                     using (tracer.Step("Deleting outdated zip file {0}", fileName))

--- a/Kudu.Core/Deployment/Oryx/BuildArtifactType.cs
+++ b/Kudu.Core/Deployment/Oryx/BuildArtifactType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kudu.Core.Deployment.Oryx
+{
+    public enum BuildArtifactType
+    {
+        Zip,
+        Squashfs
+    }
+}

--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -29,6 +29,10 @@ namespace Kudu.Core.Deployment.Oryx
         {
             public static readonly string ExpressBuildSetup = "/tmp/build/expressbuild";
             public static readonly string PythonPackagesTargetDir = Path.Combine(".python_packages", "lib", "python3.6", "site-packages");
+
+            // Determine how many built files should be kept in the container
+            public static readonly int ExpressBuildMaxFiles = 3;
+            public static readonly int ConsumptionBuildMaxFiles = 1;
         }
     }
 }

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -8,6 +8,7 @@ using Kudu.Contracts.Tracing;
 using Kudu.Contracts.Settings;
 using Kudu.Core;
 using Kudu.Core.Deployment;
+using Kudu.Core.Deployment.Oryx;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
 using Kudu.Services.Infrastructure;
@@ -442,8 +443,8 @@ namespace Kudu.Services.Deployment
                 }
             }
 
-            DeploymentHelper.PurgeZipsIfNecessary(_environment.SitePackagesPath, tracer,
-                _settings.GetMaxZipPackageCount());
+            DeploymentHelper.PurgeBuildArtifactsIfNecessary(_environment.SitePackagesPath, BuildArtifactType.Zip,
+                tracer, _settings.GetMaxZipPackageCount());
         }
 
         private void DeleteFilesAndDirsExcept(string fileToKeep, string dirToKeep, ITracer tracer)


### PR DESCRIPTION
### Dependencies
KuduLiteBuild https://github.com/Azure-App-Service/KuduLiteBuild/pull/12

### Background
We want to allow KuduLite to generate .squashfs package when after running the oryx build for functionapp. This lifts the performance and reduce the function load time, especially when a user package has mountains of small files (such as /node_modules in node, /site-packages in python).

### Changes
1. Introduce two different file extensions in KuduLite (**.zip** and **.squashfs**)
2. Allow function app build process to use **.squashfs** in **PackageArtifactFromFolder**, using `mksquashfs . {file} -noappend`
3. Default **SetupLinuxConsumptionFunctionAppDeployment** to build Linux Consumption function app in **.squashfs**

@ahmelsayed @ankitkumarr @JennyLawrance