### PR TITLE
[functionapp] Do not overwrite user settings in Linux Consumption

### DIFF
--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
@@ -85,8 +85,15 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
                     Dictionary<string, string> newSettings = FunctionAppSpecializationHelper.HandleLinuxConsumption(key, value);
                     foreach (KeyValuePair<string, string> newSetting in newSettings)
                     {
-                        System.Environment.SetEnvironmentVariable(newSetting.Key, newSetting.Value);
-                        _settingsManager.SetValue(newSetting.Key, newSetting.Value);
+                        if (System.Environment.GetEnvironmentVariable(newSetting.Key) == null)
+                        {
+                            System.Environment.SetEnvironmentVariable(newSetting.Key, newSetting.Value);
+                        }
+
+                        if (_settingsManager.GetValue(newSetting.Key) == null)
+                        {
+                            _settingsManager.SetValue(newSetting.Key, newSetting.Value);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Background
Containers running in Linux Consumption plan will have 2 phases to set the appsettings.
In the first stage, the appsetting is set by user.
In the second stage, the appsetting is set by **FunctionAppSpecializationHelper**.

The **FunctionAppSpecializationHelper** will automatically set the values like **FRAMEWORK**, **FRAMEWORK_VERSION**, **ENABLE_ORYX_BUILD** and **SCM_DO_BUILD_DURING_DEPLOYMENT**.

These values should not overwrite the user settings. We should only set these values when they are empty.