### PR TITLE
Enable oryx build for other languages in Linux Consumption

### DIFF
--- a/Kudu.Core/Helpers/FunctionAppSpecializationHelper.cs
+++ b/Kudu.Core/Helpers/FunctionAppSpecializationHelper.cs
@@ -22,20 +22,10 @@ namespace Kudu.Core.Helpers
             Dictionary<string, string> toBeUpdatedEnv = new Dictionary<string, string>();
             if (envKey == OryxBuildConstants.FunctionAppEnvVars.WorkerRuntimeSetting)
             {
-                HandleFunctionWorkerRuntime(toBeUpdatedEnv, envValue);
+                toBeUpdatedEnv.Add(SettingsKeys.DoBuildDuringDeployment, "true");
+                toBeUpdatedEnv.Add(OryxBuildConstants.EnableOryxBuild, "true");
             }
             return toBeUpdatedEnv;
-        }
-
-        private static void HandleFunctionWorkerRuntime(IDictionary<string, string> result, string workerRuntime)
-        {
-            if (workerRuntime == "python")
-            {
-                result.Add(SettingsKeys.DoBuildDuringDeployment, "true");
-                result.Add(OryxBuildConstants.EnableOryxBuild, "true");
-                result.Add(OryxBuildConstants.OryxEnvVars.FrameworkSetting, "PYTHON");
-                result.Add(OryxBuildConstants.OryxEnvVars.FrameworkVersionSetting, "3.6");
-            }
         }
     }
 }


### PR DESCRIPTION
- Allow Linux Consumption Functionapps (with other languages) to run Oryx Build in KuduLite.
- Remove `FRAMEWORK setting` and `FRAMEWORK_VERSION setting`, because they will be derived in `LinuxConsumptionFunctionAppOryxArguments`
- Currently, only Linux Consumption is using FunctionAppSpecializationHelper.cs 