### PR TITLE
Fix oryx build for dotnet Linux Consumption function app 

### DIFF
--- a/Kudu.Core/Deployment/Generator/OryxBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/OryxBuilder.cs
@@ -183,6 +183,9 @@ namespace Kudu.Core.Deployment.Generator
             // Upload from DeploymentsPath
             await UploadLinuxConsumptionFunctionAppBuiltContent(context, sas, filePath);
 
+            // Clean up local built content
+            FileSystemHelpers.DeleteDirectoryContentsSafe(context.OutputPath);
+
             // Remove Linux consumption plan functionapp workers for the site
             await RemoveLinuxConsumptionFunctionAppWorkers(context);
         }

--- a/Kudu.Core/Deployment/Generator/OryxBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/OryxBuilder.cs
@@ -172,7 +172,7 @@ namespace Kudu.Core.Deployment.Generator
         private async Task SetupLinuxConsumptionFunctionAppDeployment(DeploymentContext context)
         {
             string sas = System.Environment.GetEnvironmentVariable(Constants.ScmRunFromPackage);
-            string builtFolder = context.RepositoryPath;
+            string builtFolder = context.OutputPath;
             string packageFolder = Environment.DeploymentsPath;
             string packageFileName = $"{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}.squashfs";
 

--- a/Kudu.Core/Deployment/Oryx/LinuxConsumptionFunctionAppOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/LinuxConsumptionFunctionAppOryxArguments.cs
@@ -16,7 +16,7 @@ namespace Kudu.Core.Deployment.Oryx
         {
             StringBuilder args = new StringBuilder();
 
-            base.AddOryxBuildCommand(args, context, source: context.RepositoryPath, destination: context.RepositoryPath);
+            base.AddOryxBuildCommand(args, context, source: context.RepositoryPath, destination: context.OutputPath);
             base.AddLanguage(args, base.FunctionsWorkerRuntime);
             base.AddLanguageVersion(args, base.FunctionsWorkerRuntime);
             base.AddBuildOptimizationFlags(args, context, Flags);


### PR DESCRIPTION
Oryx Build will generate an inner folder for .NET build when we are using the **same source and destination folder**.

For example,
oryx build . -o . --platform dotnet --platform-version 2.1
The built artifacts will be dumped to ./oryx_publish_output

In this case, Linux Consumption needs to zip ./oryx_publish_output instead of the destination folder.
Change the source and destination folder into separate directories can mitigate this issue.