### PR TITLE
Bug fixes for AntiVirus Scan feature

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -14,7 +14,7 @@ namespace Kudu
         public static string ScanDir = "/home/site/wwwroot";
         public static string ScriptPath = "/custom_scripts/daily_scan_script.sh";
         public static string ScanCommand = ScriptPath+" "+ScanDir;
-        public static string ScanTimeOutMillSec = "500000";
+        public static string ScanTimeOutMillSec = "1200000";    // 20 mins
         public static string ScanManifest = "modified_times.json";
         public static string AggregrateScanResults = "aggregrate_scans.log";
         public static string TempScanFile = "temp_scan_monitor";

--- a/Kudu.Services.Web/Pages/NewUI/Index.cshtml
+++ b/Kudu.Services.Web/Pages/NewUI/Index.cshtml
@@ -211,7 +211,7 @@
             type: "GET",
             success: function(data) {
                 console.log("deployment going on" + data["value"]);
-                //document.getElementById("lock_msg").innerHTML = data["msg"]
+
                 $('#lock_msg').text(data["msg"]);
                 if (data["value"] == 'True') {
                     $("#appsvc-welcome-banner").css("display", "none");

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -106,7 +106,13 @@ namespace Kudu.Services.Deployment
         [HttpGet]
         public IActionResult IsDeploying()
         {
-            return Json(new Dictionary<string, string>() { { "value", _deploymentLock.IsHeld.ToString() }, { "msg", _deploymentLock.GetLockMsg() } });
+            string msg = "";
+            if (_deploymentLock.IsHeld)
+            {
+                msg = _deploymentLock.GetLockMsg();
+            }
+
+            return Json(new Dictionary<string, string>() { { "value", _deploymentLock.IsHeld.ToString() }, { "msg", msg } });
         }
         
         


### PR DESCRIPTION
Bugs fixed :
Set msg as "" if deploymentLock is not held
2.Id param inconsistencies resolved while displaying the scan Id to user in track scan
3.Increased default timeout to 20mins