### PR TITLE
Added checkModified as a param to override manifest file checking

### DIFF
--- a/Kudu.Contracts/Scan/IScanManager.cs
+++ b/Kudu.Contracts/Scan/IScanManager.cs
@@ -10,7 +10,8 @@ namespace Kudu.Contracts.Scan
             String timeout,
             String mainScanDirPath,
             String id,
-            String host);
+            String host,
+            Boolean checkModified);
 
         Task<ScanStatusResult> GetScanStatus(
             String scanId,

--- a/Kudu.Services/Scan/ScanController.cs
+++ b/Kudu.Services/Scan/ScanController.cs
@@ -32,7 +32,7 @@ namespace Kudu.Services.Scan
         }
 
         [HttpGet]
-        public IActionResult ExecuteScan([FromQuery] string timeout)
+        public IActionResult ExecuteScan([FromQuery] string timeout,[FromQuery] Boolean checkModified = true)
         {
 
             if (timeout == null || timeout.Length == 0)
@@ -40,9 +40,14 @@ namespace Kudu.Services.Scan
                 timeout = Constants.ScanTimeOutMillSec;
             }
 
+            if(checkModified == null)
+            {
+                checkModified = true;
+            }
+
             //Start async scanning
             String id = DateTime.UtcNow.ToString("yyy-MM-dd_HH-mm-ssZ");
-            var result = _scanManager.StartScan(timeout, mainScanDirPath, id, Request.Headers["Host"]);
+            var result = _scanManager.StartScan(timeout, mainScanDirPath, id, Request.Headers["Host"],checkModified);
             ScanUrl obj;
 
             //Check if files were modified after last scan


### PR DESCRIPTION
Added a Boolean checkModified query parameter for start scan.
If set to false, it will start the scan regardless of any modifications done/not done after the previous scan.
By default the value is true. So by default, it will only start the scan if there are any modifications after the previous scan.