### PR TITLE
Fixed SymLink creation bug with ZipDeploy/Added write permissions for all users for files pushed thorugh zip controller

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -145,7 +145,7 @@ namespace Kudu
         public const string Extensions = "extensions";
         public const string SitePackages = "SitePackages";
         public const string PackageNameTxt = "packagename.txt";
-        public const string KuduBuild = "1.0.0.6";
+        public const string KuduBuild = "1.0.0.7";
 
         public const string WebSSHReverseProxyPortEnvVar = "KUDU_WEBSSH_PORT";
         public const string WebSSHReverseProxyDefaultPort = "3000";

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -2,6 +2,8 @@
 using Kudu.Core.SourceControl;
 using Kudu.Contracts.Tracing;
 using System.Threading.Tasks;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Kudu.Core.Deployment
 {
@@ -27,6 +29,8 @@ namespace Kudu.Core.Deployment
         public bool IsContinuous { get; set; }
         public FetchDelegate Fetch { get; set; }
         public bool AllowDeploymentWhileScmDisabled { get; set; }
+
+        public IDictionary<string, string> repositorySymlinks { get; set; }
 
         // Optional.
         // Path of the directory to be deployed to. The path should be relative to the wwwroot directory.

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
@@ -125,7 +126,6 @@ namespace Kudu.Core.Deployment
                     }
 
                     await PerformDeployment(deployInfo);
-                    Console.WriteLine("\n\n\n\n Perform deployment Over\n\n\n");
                     return FetchDeploymentRequestResult.RanSynchronously;
                 }, "Performing continuous deployment", TimeSpan.Zero);
             }

--- a/Kudu.Core/Helpers/PermissionHelper.cs
+++ b/Kudu.Core/Helpers/PermissionHelper.cs
@@ -1,9 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
 using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
 using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Infrastructure;
-using System;
 
 namespace Kudu.Core.Helpers
 {
@@ -15,6 +18,32 @@ namespace Kudu.Core.Helpers
             var exeFactory = new ExternalCommandFactory(environment, deploymentSettingManager, null);
             Executable exe = exeFactory.BuildCommandExecutable("/bin/chmod", folder, deploymentSettingManager.GetCommandIdleTimeout(), logger);
             exe.Execute("{0} \"{1}\"", permission, filePath);
+        }
+
+        public static void ChmodRecursive(string permission, string directoryPath, ITracer tracer, TimeSpan timeout)
+        {
+            string cmd = String.Format("timeout {0}s chmod {1} -R {2}",timeout.TotalSeconds, permission, directoryPath);
+            var escapedArgs = cmd.Replace("\"", "\\\"");
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    FileName = "/bin/bash",
+                    Arguments = $"-c \"{escapedArgs}\""
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+
+            if(process.ExitCode != 0)
+            {
+                throw new Exception(string.Format("Error in changing file permissions : {0}",process.ExitCode));
+            }
         }
     }
 }

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Abstractions;
@@ -373,6 +374,28 @@ namespace Kudu.Core.Infrastructure
             {
                 if (!ignoreErrors) throw;
             }
+        }
+
+        public static void CreateRelativeSymlinks(string source, string destination, TimeSpan timeout)
+        {
+            string directory = FileSystemHelpers.GetDirectoryName(source);
+            string cmd = String.Format("cd {0}; timeout {1}s  ln -s {2} {3}", directory, timeout.TotalSeconds, destination, source);
+            var escapedArgs = cmd.Replace("\"", "\\\"");
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    FileName = "/bin/bash",
+                    Arguments = $"-c \"{escapedArgs}\""
+                }
+            };
+            process.Start();
+            process.WaitForExit();
         }
 
         private static void DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, bool ignoreErrors)

--- a/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
+++ b/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -108,8 +110,10 @@ namespace Kudu.Core.Infrastructure
             return entry;
         }
 
-        public static void Extract(this ZipArchive archive, string directoryName)
+        public static IDictionary<string, string> Extract(this ZipArchive archive, string directoryName)
         {
+            IDictionary<string, string> symLinks = new Dictionary<string, string>();
+            bool isSymLink = false;
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
                 string path = Path.Combine(directoryName, entry.FullName);
@@ -126,34 +130,33 @@ namespace Kudu.Core.Infrastructure
                     {
                         fileInfo.Directory.Create();
                     }
-
                     using (Stream zipStream = entry.Open(),
-                                  fileStream = fileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
+                        fileStream = fileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
                     {
                         zipStream.CopyTo(fileStream);
                     }
 
-                    bool createSymLink = false;
+                    isSymLink = false;
                     string originalFileName = string.Empty;
+
                     if (!OSDetector.IsOnWindows())
                     {
                         try
                         {
                             using (Stream fs = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                             {
-                                byte[] buffer = new byte[10];
+                                byte[] buffer = new byte[4];
                                 fs.Read(buffer, 0, buffer.Length);
                                 fs.Close();
 
                                 var str = System.Text.Encoding.Default.GetString(buffer);
                                 if (str.StartsWith("../"))
                                 {
-                                    string fullPath = Path.GetFullPath(str);
-                                    if (fullPath.StartsWith(directoryName))
+                                    using (StreamReader reader = fileInfo.OpenText())
                                     {
-                                        createSymLink = true;
-                                        originalFileName = fullPath;
+                                        symLinks[entry.FullName] = reader.ReadToEnd();
                                     }
+                                    isSymLink = true;
                                 }
                             }
                         }
@@ -163,24 +166,22 @@ namespace Kudu.Core.Infrastructure
                         }
                     }
 
-                    fileInfo.LastWriteTimeUtc = entry.LastWriteTime.ToUniversalTime().DateTime;
-
-                    if (createSymLink)
+                    try
                     {
-                        try
-                        {
-                            fileInfo.Delete();
+                        fileInfo.LastWriteTimeUtc = entry.LastWriteTime.ToUniversalTime().DateTime;
+                    }
+                    catch(Exception)
+                    {
+                        //best effort
+                    }
 
-                            Mono.Unix.UnixFileInfo unixFileInfo = new Mono.Unix.UnixFileInfo(originalFileName);
-                            unixFileInfo.CreateSymbolicLink(path);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new Exception("Could not create symlinks : " + ex.ToString());
-                        }
+                    if(isSymLink)
+                    {
+                        fileInfo.Delete();
                     }
                 }
             }
+            return symLinks;
         }
 
         private static string EnsureTrailingSlash(string input)

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -75,7 +75,7 @@ namespace Kudu.Services.Web
         public void ConfigureServices(IServiceCollection services)
         {
             Console.WriteLine(@"Configure Services : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
-
+            FileSystemHelpers.DeleteDirectorySafe("/home/site/locks/deployment");
             services.Configure<FormOptions>(options =>
             {
                 options.MultipartBodyLengthLimit = 52428800;


### PR DESCRIPTION
This PR fixes the bug where a zip artifact with symlinks; wouldn't have the symlinks preserved. Kudu now defers the symlink creation to the end of the extraction process. It also fixes the bug with FilePermissions when using Zip Put or Zip Deploy.