### PR TITLE
ANT84 Linux Consumption Remote Build Patch

### DIFF
--- a/Kudu.Core/Deployment/DeploymentHelper.cs
+++ b/Kudu.Core/Deployment/DeploymentHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Deployment.Oryx;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -684,6 +684,15 @@ namespace Kudu.Core.Deployment
                         await builder.Build(context);
                         builder.PostBuild(context);
 
+                        if (FunctionAppHelper.LooksLikeFunctionApp() && _environment.IsOnLinuxConsumption)
+                        {
+                            // A Linux consumption function app deployment requires (no matter whether it is oryx build or basic deployment)
+                            // 1. packaging the output folder
+                            // 2. upload the artifact to user's storage account
+                            // 3. reset the container workers after deployment
+                            await LinuxConsumptionDeploymentHelper.SetupLinuxConsumptionFunctionAppDeployment(_environment, _settings, context);
+                        }
+
                         await PostDeploymentHelper.SyncFunctionsTriggers(
                             _environment.RequestId, 
                             new PostDeploymentTraceListener(tracer, logger), 

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
@@ -66,7 +67,7 @@ namespace Kudu.Core.Deployment.Generator
             string enableOryxBuild = System.Environment.GetEnvironmentVariable("ENABLE_ORYX_BUILD");
             if (!string.IsNullOrEmpty(enableOryxBuild))
             {
-                if (enableOryxBuild.Equals("true", StringComparison.OrdinalIgnoreCase))
+                if (StringUtils.IsTrueLike(enableOryxBuild))
                 {
                     return new OryxBuilder(_environment, settings, _propertyProvider, repositoryRoot);
                 }

--- a/Kudu.Core/Deployment/Oryx/LinuxConsumptionFunctionAppOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/LinuxConsumptionFunctionAppOryxArguments.cs
@@ -16,7 +16,7 @@ namespace Kudu.Core.Deployment.Oryx
         {
             StringBuilder args = new StringBuilder();
 
-            base.AddOryxBuildCommand(args, context, source: context.RepositoryPath, destination: context.RepositoryPath);
+            base.AddOryxBuildCommand(args, context, source: context.RepositoryPath, destination: context.OutputPath);
             base.AddLanguage(args, base.FunctionsWorkerRuntime);
             base.AddLanguageVersion(args, base.FunctionsWorkerRuntime);
             base.AddBuildOptimizationFlags(args, context, Flags);

--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -29,6 +29,7 @@ namespace Kudu.Core.Deployment.Oryx
         internal static class FunctionAppBuildSettings
         {
             public static readonly string ExpressBuildSetup = "/tmp/build/expressbuild";
+            public static readonly string LinuxConsumptionArtifactName = "functionappartifact.squashfs";
             public static readonly string PythonPackagesTargetDir = Path.Combine(".python_packages", "lib", "python3.6", "site-packages");
 
             // Determine how many built files should be kept in the container

--- a/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
@@ -1,14 +1,18 @@
-﻿using Kudu.Core.Deployment;
-using System;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage;
+﻿using Kudu.Contracts.Settings;
+using Kudu.Core.Deployment;
+using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Deployment.Oryx;
 using Kudu.Core.Infrastructure;
-using Kudu.Contracts.Settings;
+using Kudu.Core.Tracing;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using System.IO;
-using Kudu.Core.Deployment.Generator;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 
 namespace Kudu.Core.Helpers
 {
@@ -28,6 +32,9 @@ namespace Kudu.Core.Helpers
             // Package built content from oryx build artifact
             string filePath = PackageArtifactFromFolder(env, settings, context, builtFolder, packageFolder, packageFileName);
 
+            // Log function app dependencies to kusto (requirements.txt, package.json, .csproj)
+            await LogDependenciesFile(context.RepositoryPath);
+
             // Upload from DeploymentsPath
             await UploadLinuxConsumptionFunctionAppBuiltContent(context, sas, filePath);
 
@@ -38,7 +45,134 @@ namespace Kudu.Core.Helpers
             await RemoveLinuxConsumptionFunctionAppWorkers(context);
         }
 
-        public static async Task UploadLinuxConsumptionFunctionAppBuiltContent(DeploymentContext context, string sas, string filePath)
+        private static async Task LogDependenciesFile(string builtFolder)
+        {
+            try
+            {
+                await PrintRequirementsTxtDependenciesAsync(builtFolder);
+                await PrintPackageJsonDependenciesAsync(builtFolder);
+                PrintCsprojDependenciesAsync(builtFolder);
+            } catch (Exception)
+            {
+                KuduEventGenerator.Log().GenericEvent(
+                    ServerConfiguration.GetApplicationName(),
+                    $"dependencies,failed to parse function app dependencies",
+                    Guid.Empty.ToString(),
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
+            }
+        }
+
+        private static async Task PrintRequirementsTxtDependenciesAsync(string builtFolder)
+        {
+            string filename = "requirements.txt";
+            string requirementsTxtPath = Path.Combine(builtFolder, filename);
+            if (File.Exists(requirementsTxtPath))
+            {
+                string[] lines = await File.ReadAllLinesAsync(requirementsTxtPath);
+                foreach (string line in lines)
+                {
+                    int separatorIndex;
+                    if (line.IndexOf("==") >= 0)
+                    {
+                        separatorIndex = line.IndexOf("==");
+                    } else if (line.IndexOf(">=") >= 0)
+                    {
+                        separatorIndex = line.IndexOf(">=");
+                    } else if (line.IndexOf("<=") >= 0)
+                    {
+                        separatorIndex = line.IndexOf("<=");
+                    } else if (line.IndexOf(">") >= 0)
+                    {
+                        separatorIndex = line.IndexOf(">");
+                    } else if (line.IndexOf("<") >= 0)
+                    {
+                        separatorIndex = line.IndexOf("<");
+                    } else
+                    {
+                        separatorIndex = line.Length;
+                    }
+
+                    string package = line.Substring(0, separatorIndex).Trim();
+                    string version = line.Substring(separatorIndex).Trim();
+
+                    KuduEventGenerator.Log().GenericEvent(
+                        ServerConfiguration.GetApplicationName(),
+                        $"dependencies,python,{filename},{package},{version}",
+                        Guid.Empty.ToString(),
+                        string.Empty,
+                        string.Empty,
+                        string.Empty);
+                }
+            }
+        }
+
+        private static async Task PrintPackageJsonDependenciesAsync(string builtFolder)
+        {
+            string filename = "package.json";
+            string packageJsonPath = Path.Combine(builtFolder, filename);
+            if (File.Exists(packageJsonPath))
+            {
+                string content = await File.ReadAllTextAsync(packageJsonPath);
+                JObject jobj = JObject.Parse(content);
+                if (jobj.ContainsKey("devDependencies"))
+                {
+                    Dictionary<string, string> dictObj = jobj["devDependencies"].ToObject<Dictionary<string, string>>();
+                    foreach (string key in dictObj.Keys)
+                    {
+                        KuduEventGenerator.Log().GenericEvent(
+                            ServerConfiguration.GetApplicationName(),
+                            $"dependencies,node,{filename},{key},{dictObj[key]},devDependencies",
+                            Guid.Empty.ToString(),
+                            string.Empty,
+                            string.Empty,
+                            string.Empty);
+                    }
+                }
+
+                if (jobj.ContainsKey("dependencies"))
+                {
+                    Dictionary<string, string> dictObj = jobj["dependencies"].ToObject<Dictionary<string, string>>();
+                    foreach (string key in dictObj.Keys)
+                    {
+                        KuduEventGenerator.Log().GenericEvent(
+                            ServerConfiguration.GetApplicationName(),
+                            $"dependencies,node,{filename},{key},{dictObj[key]},dependencies",
+                            Guid.Empty.ToString(),
+                            string.Empty,
+                            string.Empty,
+                            string.Empty);
+                    }
+                }
+            }
+        }
+
+        private static void PrintCsprojDependenciesAsync(string builtFolder)
+        {
+            foreach (string csprojPath in Directory.GetFiles(builtFolder, "*.csproj", SearchOption.TopDirectoryOnly))
+            {
+                string filename = Path.GetFileName(csprojPath);
+                XElement purchaseOrder = XElement.Load(csprojPath);
+                foreach (var itemGroup in purchaseOrder.Elements("ItemGroup"))
+                {
+                    foreach (var packageReference in itemGroup.Elements("PackageReference"))
+                    {
+                        string include = packageReference.Attribute("Include").Value;
+                        string version = packageReference.Attribute("Version").Value;
+                        KuduEventGenerator.Log().GenericEvent(
+                            ServerConfiguration.GetApplicationName(),
+                            $"dependencies,dotnet,{filename},{include},{version}",
+                            Guid.Empty.ToString(),
+                            string.Empty,
+                            string.Empty,
+                            string.Empty);
+                    }
+                }
+            }
+        }
+
+        private static async Task UploadLinuxConsumptionFunctionAppBuiltContent(DeploymentContext context, string sas, string filePath)
         {
             context.Logger.Log($"Uploading built content {filePath} -> {sas}");
 
@@ -71,7 +205,7 @@ namespace Kudu.Core.Helpers
             }
         }
 
-        public static async Task RemoveLinuxConsumptionFunctionAppWorkers(DeploymentContext context)
+        private static async Task RemoveLinuxConsumptionFunctionAppWorkers(DeploymentContext context)
         {
             string webSiteHostName = System.Environment.GetEnvironmentVariable(SettingsKeys.WebsiteHostname);
             string sitename = ServerConfiguration.GetApplicationName();

--- a/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
@@ -1,0 +1,121 @@
+﻿using Kudu.Core.Deployment;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage;
+using Kudu.Core.Deployment.Oryx;
+using Kudu.Core.Infrastructure;
+using Kudu.Contracts.Settings;
+using System.IO;
+using Kudu.Core.Deployment.Generator;
+
+namespace Kudu.Core.Helpers
+{
+    public class LinuxConsumptionDeploymentHelper
+    {
+        /// <summary>
+        /// Specifically used for Linux Consumption to support Server Side build scenario
+        /// </summary>
+        /// <param name="context"></param>
+        public static async Task SetupLinuxConsumptionFunctionAppDeployment(IEnvironment env, IDeploymentSettingsManager settings, DeploymentContext context)
+        {
+            string sas = System.Environment.GetEnvironmentVariable(Constants.ScmRunFromPackage);
+            string builtFolder = context.OutputPath;
+            string packageFolder = env.DeploymentsPath;
+            string packageFileName = OryxBuildConstants.FunctionAppBuildSettings.LinuxConsumptionArtifactName;
+
+            // Package built content from oryx build artifact
+            string filePath = PackageArtifactFromFolder(env, settings, context, builtFolder, packageFolder, packageFileName);
+
+            // Upload from DeploymentsPath
+            await UploadLinuxConsumptionFunctionAppBuiltContent(context, sas, filePath);
+
+            // Clean up local built content
+            FileSystemHelpers.DeleteDirectoryContentsSafe(context.OutputPath);
+
+            // Remove Linux consumption plan functionapp workers for the site
+            await RemoveLinuxConsumptionFunctionAppWorkers(context);
+        }
+
+        public static async Task UploadLinuxConsumptionFunctionAppBuiltContent(DeploymentContext context, string sas, string filePath)
+        {
+            context.Logger.Log($"Uploading built content {filePath} -> {sas}");
+
+            // Check if SCM_RUN_FROM_PACKAGE does exist
+            if (string.IsNullOrEmpty(sas))
+            {
+                context.Logger.Log($"Failed to upload because SCM_RUN_FROM_PACKAGE is not provided.");
+                throw new DeploymentFailedException(new ArgumentException("Failed to upload because SAS is empty."));
+            }
+
+            // Parse SAS
+            Uri sasUri = null;
+            if (!Uri.TryCreate(sas, UriKind.Absolute, out sasUri))
+            {
+                context.Logger.Log($"Malformed SAS when uploading built content.");
+                throw new DeploymentFailedException(new ArgumentException("Failed to upload because SAS is malformed."));
+            }
+
+            // Upload blob to Azure Storage
+            CloudBlockBlob blob = new CloudBlockBlob(sasUri);
+            try
+            {
+                await blob.UploadFromFileAsync(filePath);
+            }
+            catch (StorageException se)
+            {
+                context.Logger.Log($"Failed to upload because Azure Storage responds {se.RequestInformation.HttpStatusCode}.");
+                context.Logger.Log(se.Message);
+                throw new DeploymentFailedException(se);
+            }
+        }
+
+        public static async Task RemoveLinuxConsumptionFunctionAppWorkers(DeploymentContext context)
+        {
+            string webSiteHostName = System.Environment.GetEnvironmentVariable(SettingsKeys.WebsiteHostname);
+            string sitename = ServerConfiguration.GetApplicationName();
+
+            context.Logger.Log($"Reseting all workers for {webSiteHostName}");
+
+            try
+            {
+                await OperationManager.AttemptAsync(async () =>
+                {
+                    await PostDeploymentHelper.RemoveAllWorkersAsync(webSiteHostName, sitename);
+                }, retries: 3, delayBeforeRetry: 2000);
+            }
+            catch (ArgumentException ae)
+            {
+                context.Logger.Log($"Reset all workers has malformed webSiteHostName or sitename {ae.Message}");
+                throw new DeploymentFailedException(ae);
+            }
+            catch (HttpRequestException hre)
+            {
+                context.Logger.Log($"Reset all workers endpoint responded with {hre.Message}");
+                throw new DeploymentFailedException(hre);
+            }
+        }
+
+        private static string PackageArtifactFromFolder(IEnvironment environment, IDeploymentSettingsManager settings, DeploymentContext context, string srcDirectory, string artifactDirectory, string artifactFilename)
+        {
+            context.Logger.Log("Writing the artifacts to a squashfs file");
+            string file = Path.Combine(artifactDirectory, artifactFilename);
+            ExternalCommandFactory commandFactory = new ExternalCommandFactory(environment, settings, context.RepositoryPath);
+            Executable exe = commandFactory.BuildExternalCommandExecutable(srcDirectory, artifactDirectory, context.Logger);
+            try
+            {
+                exe.ExecuteWithProgressWriter(context.Logger, context.Tracer, $"mksquashfs . {file} -noappend");
+            }
+            catch (Exception)
+            {
+                context.GlobalLogger.LogError();
+                throw;
+            }
+
+            int numOfArtifacts = OryxBuildConstants.FunctionAppBuildSettings.ConsumptionBuildMaxFiles;
+            DeploymentHelper.PurgeBuildArtifactsIfNecessary(artifactDirectory, BuildArtifactType.Squashfs, context.Tracer, numOfArtifacts);
+            return file;
+        }
+    }
+}

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -301,7 +301,7 @@ namespace Kudu.Services.Deployment
                 case FetchDeploymentRequestResult.ConflictDeploymentInProgress:
                     return StatusCode(StatusCodes.Status409Conflict, Resources.Error_DeploymentInProgress);
                 case FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured:
-                    return StatusCode(StatusCodes.Status409Conflict, Resources.Error_AutoSwapDeploymentOngoing);
+                    return StatusCode(StatusCodes.Status409Conflict, Resources.Error_RunFromRemoteZipConfigured);
                 default:
                     return BadRequest();
             }

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
@@ -56,14 +56,7 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
             var containerKey = System.Environment.GetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey);
             var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);
 
-            // before starting the assignment we want to perform as much
-            // up front validation on the context as possible
-            string error = await _instanceManager.ValidateContext(assignmentContext);
-            if (error != null)
-            {
-                return StatusCode(StatusCodes.Status400BadRequest, error);
-            }
-
+            // We don't need to do validation on run_from_package zip, scm site on Linux Consumption should always be on
             var assignmentResult = _instanceManager.StartAssignment(assignmentContext);
 
             // modify app settings from environment variables (for all start with "APPSETTING_")

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionRouteMiddleware.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionRouteMiddleware.cs
@@ -26,6 +26,9 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
         private static readonly HashSet<string> Whitelist = new HashSet<string>
         {
             "/api/zipdeploy",
+            "/api/deployments",
+            "/api/isdeploying",
+            "/api/settings",
             "/admin/instance",
             "/deployments",
         };

--- a/Kudu.Services/Resources.Designer.cs
+++ b/Kudu.Services/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace Kudu.Services {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run-From-Zip is set to a remote URL using WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration..
+        ///   Looks up a localized string similar to Run-From-Zip is set to a remote URL using WEBSITE_RUN_FROM_PACKAGE or WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration..
         /// </summary>
         internal static string Error_RunFromRemoteZipConfigured {
             get {
@@ -376,14 +376,14 @@ namespace Kudu.Services {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check reults of last scan.
+        ///   Looks up a localized string similar to Check results of last scan.
         /// </summary>
         internal static string LastScanMsg {
             get {
                 return ResourceManager.GetString("LastScanMsg", resourceCulture);
             }
         }
-               
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}{1}  The application was terminated.{0}.
         /// </summary>
@@ -556,7 +556,7 @@ namespace Kudu.Services {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Scan is already in progress..
+        ///   Looks up a localized string similar to Something is blocking the scan. It might be that a scan is already in progress or a deployment is underway..
         /// </summary>
         internal static string ScanInProgress {
             get {

--- a/Kudu.Services/Resources.resx
+++ b/Kudu.Services/Resources.resx
@@ -172,7 +172,7 @@
     <value>There is a deployment currently in progress. Please try again when it completes.</value>
   </data>
   <data name="Error_RunFromRemoteZipConfigured" xml:space="preserve">
-    <value>Run-From-Zip is set to a remote URL using WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration.</value>
+    <value>Run-From-Zip is set to a remote URL using WEBSITE_RUN_FROM_PACKAGE or WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration.</value>
   </data>
   <data name="Error_DeploymentNotFound" xml:space="preserve">
     <value>Deployment '{0}' not found.</value>


### PR DESCRIPTION
### Changes
1. Expose **/api/deployments**,  **/api/isdeploying** and **/api/settings** endpoints since the site authentication token will be attached (We are secured enough to open these up. If a malicious user attempts to go to SCM site via IP address, its authentication will fail now).
2. Refactor out LinuxConsumption remote build logic from OryxBuilder.cs to LinuxConsumptionDeploymentHelper.cs (This includes post-build compression, uploading artifact to customer's storage account, logging dependencies information, cleaning up artifact folder)

### Bug Fixes
1. Clean up artifact folder in case if the KuduLite container is reused
2. Remove unnecessary validation on WEBSITE_RUN_FROM_PACKAGE value

### Improvements
1. ENABLE_ORYX_BUILD now also accepts "1" and other true-like value (previously we only accepts "true")
2. Add package dependencies telemetry from user's function app oryx build (Linux Consumption only, log dependencies in package.json, requirements.txt, functionapp.csproj).
3. Allow user to set ENABLE_ORYX_BUILD=false and DO_BUILD_DURING_DEPLOYMENT=false to use /api/zipdeploy for Linux Consumption functionapp deployment without oryx build.
4. Update error message when a customer use api/zipdeploy with WEBSITE_RUN_FROM_PACKAGE setting