### PR TITLE
Fix python 3.7 path in Oryx Build

### DIFF
--- a/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
@@ -79,10 +79,6 @@ namespace Kudu.Core.Deployment.Oryx
                     Language = Framework.Python;
                     OryxArgumentsHelper.AddLanguage(args, "python");
                     break;
-                case WorkerRuntime.PHP:
-                    Language = Framework.PHP;
-                    OryxArgumentsHelper.AddLanguage(args, "php");
-                    break;
             }
         }
 
@@ -118,7 +114,14 @@ namespace Kudu.Core.Deployment.Oryx
             switch (workerRuntime)
             {
                 case WorkerRuntime.Python:
-                    OryxArgumentsHelper.AddPythonPackageDir(args, OryxBuildConstants.FunctionAppBuildSettings.PythonPackagesTargetDir);
+                    if (Version == "3.6")
+                    {
+                        // Backward compatible with current python 3.6
+                        OryxArgumentsHelper.AddPythonPackageDir(args, OryxBuildConstants.FunctionAppBuildSettings.Python36PackagesTargetDir);
+                    } else
+                    {
+                        OryxArgumentsHelper.AddPythonPackageDir(args, OryxBuildConstants.FunctionAppBuildSettings.PythonPackagesTargetDir);
+                    }
                     break;
             }
         }

--- a/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/FunctionAppOryxArguments.cs
@@ -118,7 +118,8 @@ namespace Kudu.Core.Deployment.Oryx
                     {
                         // Backward compatible with current python 3.6
                         OryxArgumentsHelper.AddPythonPackageDir(args, OryxBuildConstants.FunctionAppBuildSettings.Python36PackagesTargetDir);
-                    } else
+                    }
+                    else
                     {
                         OryxArgumentsHelper.AddPythonPackageDir(args, OryxBuildConstants.FunctionAppBuildSettings.PythonPackagesTargetDir);
                     }

--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -30,7 +30,8 @@ namespace Kudu.Core.Deployment.Oryx
         {
             public static readonly string ExpressBuildSetup = "/tmp/build/expressbuild";
             public static readonly string LinuxConsumptionArtifactName = "functionappartifact.squashfs";
-            public static readonly string PythonPackagesTargetDir = Path.Combine(".python_packages", "lib", "python3.6", "site-packages");
+            public static readonly string Python36PackagesTargetDir = Path.Combine(".python_packages", "lib", "python3.6", "site-packages");
+            public static readonly string PythonPackagesTargetDir = Path.Combine(".python_packages", "lib", "site-packages");
 
             // Determine how many built files should be kept in the container
             public static readonly int ExpressBuildMaxFiles = 3;


### PR DESCRIPTION
We want to remove the version specific python3.6 or python3.7 in the site-packages path.
