### PR TITLE
Fix missing Docker logs

### DIFF
--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
@@ -20,6 +21,13 @@ using System.Threading.Tasks;
 
 namespace Kudu.Services.Performance
 {
+    class DockerLogSourceMap
+    {
+        public string LogSource { get; set; } // RDxxxxxxxxxxxx + "_" + default, easyauth, "" (i.e. Docker), etc.
+        public int Timestamp { get; set; }  // YYYYmmDD
+        public List<string> Paths { get; set; }
+    }
+
     public class DiagnosticsController : Controller
     {
         // Matches Docker log filenames of logs that haven't been rolled (are most current for a given machine name)
@@ -27,7 +35,7 @@ namespace Kudu.Services.Performance
         // Examples:
         //   2017_08_23_RD00155DD0D38E_docker.log (not rolled)
         //   2017_08_23_RD00155DD0D38E_docker.1.log (rolled)
-        private static readonly Regex NONROLLED_DOCKER_LOG_FILENAME_REGEX = new Regex(@"^\d{4}_\d{2}_\d{2}_.*_docker\.log$");
+        private static readonly Regex NONROLLED_DOCKER_LOG_FILENAME_REGEX = new Regex(@"^(\d{4}_\d{2}_\d{2})_(.*)_docker\.log$");
 
         private readonly DiagnosticsSettingsManager _settingsManager;
         private readonly string[] _paths;
@@ -150,27 +158,42 @@ namespace Kudu.Services.Performance
 
         private string[] GetCurrentDockerLogFilenames(SearchOption searchOption)
         {
-            // Get all non-rolled Docker log filenames from the LogFiles directory
-            var nonRolledDockerLogFilenames =
-                FileSystemHelpers.ListFiles(_environment.LogFilesPath, searchOption, new[] { "*" })
-                .Where(f => NONROLLED_DOCKER_LOG_FILENAME_REGEX.IsMatch(Path.GetFileName(f)))
-                .ToArray();
+            var allDockerLogFilenames = FileSystemHelpers.ListFiles(_environment.LogFilesPath, searchOption, new[] { "*" }).ToArray();
+            var logSources = new Dictionary<string, DockerLogSourceMap>();
 
-            if (!nonRolledDockerLogFilenames.Any())
+            // Get all non-rolled Docker log filenames from the LogFiles directory
+            foreach (var dockerLogPath in allDockerLogFilenames)
+            {
+                var match = NONROLLED_DOCKER_LOG_FILENAME_REGEX.Match(Path.GetFileName(dockerLogPath));
+                if (match.Success)
+                {
+                    // Get the timestamp and log source (machine name "_" default, easyauth, empty(Docker), etc) from the file name
+                    // and find the latest one for each source
+                    // Note that timestamps are YYYY_MM_DD (sortable as integers with the underscores removed)
+                    var date = int.Parse(match.Groups[1].Value.Replace("_", String.Empty));
+                    var source = match.Groups[2].Value;
+
+                    if (!logSources.ContainsKey(source) || logSources[source].Timestamp < date)
+                    {
+                        logSources[source] = new DockerLogSourceMap {
+                            LogSource = source,
+                            Timestamp = date,
+                            Paths = new List<string> { dockerLogPath }
+                        };
+                    }
+                    else
+                    {
+                        logSources[source].Paths.Add(dockerLogPath);
+                    }
+                }
+            }
+
+            if (logSources.Keys.Count == 0)
             {
                 return new string[0];
             }
 
-            // Find the latest date stamp and filter out those that don't have it
-            // Timestamps are YYYY_MM_DD (sortable as integers with the underscores removed)
-            var latestDatestamp = nonRolledDockerLogFilenames
-                .Select(p => Path.GetFileName(p).Substring(0, 10))
-                .OrderByDescending(s => int.Parse(s.Replace("_", String.Empty)))
-                .First();
-
-            return nonRolledDockerLogFilenames
-                .Where(f => Path.GetFileName(f).StartsWith(latestDatestamp, StringComparison.OrdinalIgnoreCase))
-                .ToArray();
+            return logSources.Values.SelectMany(m => m.Paths).ToArray();
         }
 
         private JObject CurrentDockerLogFilenameToJson(string path, string vfsBaseAddress)


### PR DESCRIPTION
There is an issue with api/logs/docker API where some logs are missing in a certain condition. For example, when there are the following logs, only the last one is returned by the API:

2019_10_14_RD0003FFAA2EA3_default_docker.log
2019_10_14_RD0003FFAA2EA3_docker.log
2019_10_14_RD0003FFAA2EA3_easyauth_docker.log
2019_10_15_RD0003FFAA2EA3_easyauth_docker.log

This is because the last one has the latest date (2019-10-15). This ends up with docker and application logs are missing.

This PR changes the behavior of the API such that it returns the list of files for each "source" (a combination of machine name and type.) The types include EasyAuth, default (i.e. application itself), an empty string from the docker daemon, etc.

The side effect is that if the app has been existing for a long time, it may return many files because the app has been running on many different machines and some of them may be very old. I could update this behavior by checking the timestamp and pick up only logs in the last few days. I would like your feedback regarding this.