### PR TITLE
Trigger a recycle after wardeploy

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -98,6 +98,8 @@ namespace Kudu
         public const string LogicAppJson = "logicapp.json";
         public const string LogicAppUrlKey = "LOGICAPP_URL";
 
+        public const string RestartApiPath = "/api/app/restart";
+
         public const string SiteExtensionProvisioningStateCreated = "Created";
         public const string SiteExtensionProvisioningStateAccepted = "Accepted";
         public const string SiteExtensionProvisioningStateSucceeded = "Succeeded";
@@ -118,6 +120,7 @@ namespace Kudu
         public const string SiteRestrictedToken = "x-ms-site-restricted-token";
         public const string SiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string HttpHost = "HTTP_HOST";
+        public const string HttpAuthority = "HTTP_AUTHORITY";
         public const string WebSiteSwapSlotName = "WEBSITE_SWAP_SLOTNAME";
         public const string AzureWebsiteInstanceId = "WEBSITE_INSTANCE_ID";
         public const string ContainerName = "CONTAINER_NAME";

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -234,12 +234,20 @@ namespace Kudu.Contracts.Settings
             return StringUtils.IsTrueLike(value);
         }
 
-        public static bool RestartAppContainerOnGitDeploy(this IDeploymentSettingsManager settings)
+        public static bool RestartAppOnGitDeploy(this IDeploymentSettingsManager settings)
         {
-            string value = settings.GetValue(SettingsKeys.LinuxRestartAppContainerAfterDeployment);
+            string value = settings.GetValue(SettingsKeys.RestartAppAfterDeployment);
 
             // Default is true
             return value == null || StringUtils.IsTrueLike(value);
+        }
+
+        public static bool RecylePreviewEnabled(this IDeploymentSettingsManager settings)
+        {
+            string value = settings.GetValue(SettingsKeys.RecyclePreviewEnabled);
+
+            // Default value, if setting is not explicitly defined, is false
+            return StringUtils.IsTrueLike(value);
         }
 
         public static bool DoBuildDuringDeployment(this IDeploymentSettingsManager settings)

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -41,10 +41,18 @@
         public const string TouchWebConfigAfterDeployment = "SCM_TOUCH_WEBCONFIG_AFTER_DEPLOYMENT";
         public const string MaxRandomDelayInSec = "SCM_MAX_RANDOM_START_DELAY";
         public const string DockerCiEnabled = "DOCKER_ENABLE_CI";
-        public const string LinuxRestartAppContainerAfterDeployment = "SCM_RESTART_APP_CONTAINER_AFTER_DEPLOYMENT";
+
+        // This app-setting works for all kinds of apps, including classic Windows apps (not just container-based apps).
+        // To make it work for Windows apps, the app-setting WEBSITE_RECYCLE_PREVIEW_ENABLED=1 needs to be defined.
+        public const string RestartAppAfterDeployment = "SCM_RESTART_APP_CONTAINER_AFTER_DEPLOYMENT";
+
         public const string DoBuildDuringDeployment = "SCM_DO_BUILD_DURING_DEPLOYMENT";
         public const string RunFromZipOld = "WEBSITE_RUN_FROM_ZIP";  // Old name, will eventually go away
         public const string RunFromZip = "WEBSITE_RUN_FROM_PACKAGE";
+
+        // Temporary flag intended only for testing purposes. Will not be supported for too long.
+        public const string RecyclePreviewEnabled = "WEBSITE_RECYCLE_PREVIEW_ENABLED";
+
         public const string MaxZipPackageCount = "SCM_MAX_ZIP_PACKAGE_COUNT";
         // Antares container specific settings
         public const string PlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -248,14 +248,6 @@ namespace Kudu.Core.Deployment
 
                         // Perform the build deployment of this changeset
                         await Build(changeSet, tracer, deployStep, repository, deploymentInfo, deploymentAnalytics, fullBuildByDefault);
-
-                        if (!(OSDetector.IsOnWindows() && 
-                              !EnvironmentHelper.IsWindowsContainers()) && 
-                            _settings.RestartAppContainerOnGitDeploy())
-                        {
-                            logger.Log(Resources.Log_TriggeringContainerRestart);
-                            DockerContainerRestartTrigger.RequestContainerRestart(_environment, RestartTriggerReason);
-                        }
                     }
                     catch (Exception ex)
                     {
@@ -297,6 +289,30 @@ namespace Kudu.Core.Deployment
                         throw new DeploymentFailedException(exception);
                     }
            
+            }
+        }
+
+        public async Task RestartMainSiteIfNeeded(ITracer tracer, ILogger logger)
+        {
+            // If post-deployment restart is disabled, do nothing.
+            if (!_settings.RestartAppOnGitDeploy())
+            {
+                return;
+            }
+
+            if (_settings.RecylePreviewEnabled())
+            {
+                logger.Log("Triggering recycle (preview mode enabled).");
+                tracer.Trace("Triggering recycle (preview mode enabled).");
+
+                await PostDeploymentHelper.RestartMainSiteAsync(_environment.RequestId, new PostDeploymentTraceListener(tracer, logger));
+            }
+            else
+            {
+                logger.Log("Triggering recycle (preview mode disabled).");
+                tracer.Trace("Triggering recycle (preview mode disabled).");
+
+                DockerContainerRestartTrigger.RequestContainerRestart(_environment, RestartTriggerReason, tracer);
             }
         }
 
@@ -683,6 +699,8 @@ namespace Kudu.Core.Deployment
                     {
                         await builder.Build(context);
                         builder.PostBuild(context);
+
+                        await RestartMainSiteIfNeeded(tracer, logger);
 
                         if (FunctionAppHelper.LooksLikeFunctionApp() && _environment.IsOnLinuxConsumption)
                         {

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -23,6 +23,8 @@ namespace Kudu.Core.Helpers
     public static class PostDeploymentHelper
     {
         public const string AutoSwapLockFile = "autoswap.lock";
+        public const int RestartRetryIntervalInMilliSeconds = 5 * 1000; // 5 seconds
+        public const int RestartRetryCount = 5;
 
         private static Lazy<ProductInfoHeaderValue> _userAgent = new Lazy<ProductInfoHeaderValue>(() =>
         {
@@ -50,6 +52,12 @@ namespace Kudu.Core.Helpers
         private static string HttpHost
         {
             get { return System.Environment.GetEnvironmentVariable(Constants.HttpHost); }
+        }
+
+        // HTTP_AUTHORITY = host:port. Port is optional. Example: site.scm.azurewebsites.net or localhost:11212
+        private static string HttpAuthority
+        {
+            get { return System.Environment.GetEnvironmentVariable(Constants.HttpAuthority); }
         }
 
         // WEBSITE_SWAP_SLOTNAME = Production
@@ -98,6 +106,11 @@ namespace Kudu.Core.Helpers
         private static string HomeStamp
         {
             get { return System.Environment.GetEnvironmentVariable("WEBSITE_HOME_STAMPNAME"); }
+        }
+
+        private static bool IsLocalHost
+        {
+            get { return HttpHost.Equals("localhost", StringComparison.OrdinalIgnoreCase); }
         }
 
         /// <summary>
@@ -313,6 +326,37 @@ namespace Kudu.Core.Helpers
             return !string.IsNullOrEmpty(WebSiteSwapSlotName);
         }
 
+        public static async Task RestartMainSiteAsync(string requestId, TraceListener tracer)
+        {
+            _tracer = tracer;
+
+            Trace(tracer, TraceEventType.Information, "Requesting site restart");
+
+            VerifyEnvironments();
+
+            int attemptCount = 0;
+
+            try
+            {
+                await OperationManager.AttemptAsync(async () =>
+                {
+                    attemptCount++;
+
+                    Trace(tracer, TraceEventType.Information, $"Requesting site restart. Attempt #{attemptCount}");
+
+                    await PostAsync(Constants.RestartApiPath, requestId, null);
+
+                    Trace(tracer, TraceEventType.Information, $"Successfully requested a restart. Attempt #{attemptCount}");
+
+                }, RestartRetryCount, RestartRetryIntervalInMilliSeconds);
+            }
+            catch(Exception ex)
+            {
+                Trace(tracer, TraceEventType.Information, $"Failed to request a restart. Number of attempts: {attemptCount}. Exception: {ex}");
+                throw;
+            }
+        }
+
         public static async Task PerformAutoSwap(string requestId, TraceListener tracer)
         {
             _tracer = tracer;
@@ -470,26 +514,27 @@ namespace Kudu.Core.Helpers
             }
         }
 
+        // Throws on failure
         private static async Task PostAsync(string path, string requestId, string content = null)
         {
-            var host = HttpHost;
-            var ipAddress = await GetAlternativeIPAddress(host);
+            var hostOrAuthority = IsLocalHost ? HttpAuthority : HttpHost;
+            var scheme = IsLocalHost ? "http" : "https";
+            var ipAddress = await GetAlternativeIPAddress(hostOrAuthority);
             var statusCode = default(HttpStatusCode);
-            Trace(TraceEventType.Verbose, "Begin HttpPost https://{0}{1}, x-ms-request-id: {2}", host, path, requestId);
             try
             {
                 using (var client = HttpClientFactory())
                 {
                     if (ipAddress == null)
                     {
-                        Trace(TraceEventType.Verbose, "Begin HttpPost https://{0}{1}, x-ms-request-id: {2}", host, path, requestId);
-                        client.BaseAddress = new Uri(string.Format("https://{0}", host));
+                        Trace(TraceEventType.Verbose, "Begin HttpPost {0}://{1}{2}, x-ms-request-id: {3}", scheme, hostOrAuthority, path, requestId);
+                        client.BaseAddress = new Uri(string.Format("{0}://{1}", scheme, hostOrAuthority));
                     }
                     else
                     {
-                        Trace(TraceEventType.Verbose, "Begin HttpPost https://{0}{1}, host: {2}, x-ms-request-id: {3}", ipAddress, path, host, requestId);
-                        client.BaseAddress = new Uri(string.Format("https://{0}", ipAddress));
-                        client.DefaultRequestHeaders.Host = host;
+                        Trace(TraceEventType.Verbose, "Begin HttpPost {0}://{1}{2}, host: {3}, x-ms-request-id: {4}", scheme, ipAddress, path, hostOrAuthority, requestId);
+                        client.BaseAddress = new Uri(string.Format("{0}://{1}", scheme, ipAddress));
+                        client.DefaultRequestHeaders.Host = hostOrAuthority;
                     }
 
                     client.DefaultRequestHeaders.UserAgent.Add(_userAgent.Value);
@@ -509,7 +554,7 @@ namespace Kudu.Core.Helpers
                 Trace(TraceEventType.Verbose, "End HttpPost, status: {0}", statusCode);
             }
         }
-        
+
         /// <summary>
         /// This works around the hostname dns resolution issue for recently created site.
         /// If dns failed, we will use the home hosted service as alternative IP address.
@@ -728,7 +773,11 @@ namespace Kudu.Core.Helpers
 
         private static void Trace(TraceEventType eventType, string format, params object[] args)
         {
-            var tracer = _tracer;
+            Trace(_tracer, eventType, format, args);
+        }
+
+        private static void Trace(TraceListener tracer, TraceEventType eventType, string format, params object[] args)
+        {
             if (tracer != null)
             {
                 tracer.TraceEvent(null, "PostDeployment", eventType, (int)eventType, format, args);

--- a/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
@@ -1,7 +1,18 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using Kudu.Contracts.Tracing;
 using Kudu.Core.Helpers;
+using Kudu.Core.Tracing;
+
+// **************************************************************************************************
+// **************************************************************************************************
+//
+// WARNING!!! THIS CLASS IS DEPRECATED AND WILL SOON BE REMOVED. GOING FORWARD, restartTrigger.txt 
+// WILL NOT BE USED FOR RESTARTING A SITE. INSTEAD, THE /api/app/restart API IS THE WAY TO GO.
+// 
+// **************************************************************************************************
+// **************************************************************************************************
 
 namespace Kudu.Core.Infrastructure
 {
@@ -20,11 +31,12 @@ namespace Kudu.Core.Infrastructure
             "The last modification Kudu made to this file was at {0}, for the following reason: {1}.",
             System.Environment.NewLine);
 
-        public static void RequestContainerRestart(IEnvironment environment, string reason)
+        public static void RequestContainerRestart(IEnvironment environment, string reason, ITracer tracer)
         {
             if (OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers())
             {
-                throw new NotSupportedException("RequestContainerRestart is only supported on Linux and Windows Containers");
+                tracer.Trace("Ignoring FS watcher based recycle request as this is a classic Windows app.");
+                return;
             }
 
             var restartTriggerPath = Path.Combine(environment.SiteRootPath, CONFIG_DIR_NAME, TRIGGER_FILENAME);

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -644,7 +644,7 @@ namespace Kudu.Services.Web
                 }
 
                 // catch all unregistered url to properly handle not found
-                // routes.MapRoute("error-404", "{*path}", new {controller = "Error404", action = "Handle"});
+                routes.MapRoute("error-404", "{*path}", new {controller = "Error404", action = "Handle"});
             });
 
             Console.WriteLine(@"Exiting Configure : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));

--- a/Kudu.Services.Web/Tracing/TraceMiddleware.cs
+++ b/Kudu.Services.Web/Tracing/TraceMiddleware.cs
@@ -382,6 +382,7 @@ namespace Kudu.Services.Web.Tracing
                     StringComparison.OrdinalIgnoreCase))
                 {
                     System.Environment.SetEnvironmentVariable(Constants.HttpHost, GetHostUrl(request));
+                    System.Environment.SetEnvironmentVariable(Constants.HttpAuthority, $"{request.Host}");
                 }
             }
             catch

--- a/Kudu.Services/Docker/DockerController.cs
+++ b/Kudu.Services/Docker/DockerController.cs
@@ -38,7 +38,7 @@ namespace Kudu.Services.Docker
                 {
                     if (_settings.IsDockerCiEnabled())
                     {
-                        DockerContainerRestartTrigger.RequestContainerRestart(_environment, RESTART_REASON);
+                        DockerContainerRestartTrigger.RequestContainerRestart(_environment, RESTART_REASON, tracer);
                     }
                 }
                 catch (Exception e)

--- a/Kudu.Services/Docker/DockerController.cs
+++ b/Kudu.Services/Docker/DockerController.cs
@@ -7,6 +7,15 @@ using Kudu.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
+// **************************************************************************************************
+// **************************************************************************************************
+//
+// WARNING!!! THIS CLASS IS DEPRECATED AND WILL SOON BE REMOVED. GOING FORWARD, restartTrigger.txt 
+// WILL NOT BE USED FOR RESTARTING A SITE. INSTEAD, THE /api/app/restart API IS THE WAY TO GO.
+// 
+// **************************************************************************************************
+// **************************************************************************************************
+
 namespace Kudu.Services.Docker
 {
     public class DockerController : Controller

--- a/Kudu.Services/Error404Controller.cs
+++ b/Kudu.Services/Error404Controller.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace Kudu.Services
+{
+    public class Error404Controller : Controller
+    {
+        [HttpGet, HttpPatch, HttpPost, HttpPut, HttpDelete]
+        public virtual Task<IActionResult> Handle()
+        {
+            // Mock few paths. For development purposes only.
+            if (this.Request.Host.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                if (this.Request.Path.Equals(Constants.RestartApiPath, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult((IActionResult) Ok());
+                }
+            }
+
+            return Task.FromResult((IActionResult) NotFound($"No route registered for '{this.Request.Path}'"));
+        }
+    }
+}


### PR DESCRIPTION
- This is a port of this PR - https://github.com/projectkudu/kudu/pull/3050 - from the Kudu repo.
- Current implementation of /wardeploy triggers a recycle of container, only on Xenon and Linux. This recycle is performed using the restartTrigger.txt file.
- This commit adds support to /wardeploy for triggering a recycle of classic Windows web apps in addition to just Xenon and Linux, if the app setting WEBSITE_RECYCLE_PREVIEW_ENABLED is defined. Besides, the recyle will be performed using the /api/app/restart API.
- The new behavior is hidden behind a WEBSITE_RECYCLE_PREVIEW_ENABLED flag, which is added only temporarily. This flag will eventually be removed and the new behavior will become the default.