### PR TITLE
Fix broken Deployments for Node 12.9 and remove Oryx Symlink Files on Zip Deploy

### DIFF
--- a/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
@@ -192,12 +192,18 @@ namespace Kudu.Core.Deployment
                         // 10-LTS, 12-LTS should use versions 10, 12 etc
                         // Oryx Builder uses lts for major versions
                         Version = Version.Replace("lts", "").Replace("-", "");
-                        if (string.IsNullOrEmpty(Version))
-                        {
-                            // Active LTS
-                            Version = "10";
-                        }
                     }
+
+                    if (string.IsNullOrEmpty(Version) || Version.Contains("10.16", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Active LTS
+                        Version = "10";
+                    }
+                    else if(Version.Contains("12.9", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Version = "12";
+                    }
+
                     OryxArgumentsHelper.AddLanguageVersion(args, Version);
                     break;
                 case Framework.Python:

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -407,6 +407,28 @@ namespace Kudu.Core.Infrastructure
             process.WaitForExit();
         }
 
+        public static void RemoveUnixSymlink(string filePath, TimeSpan timeout)
+        {
+            string directory = FileSystemHelpers.GetDirectoryName(filePath);
+            string cmd = String.Format("cd {0}; timeout {1}s  rm {2}", directory, timeout.TotalSeconds, filePath);
+            var escapedArgs = cmd.Replace("\"", "\\\"");
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    FileName = "/bin/bash",
+                    Arguments = $"-c \"{escapedArgs}\""
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+        }
+
         private static void DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, bool ignoreErrors)
         {
             if (!fileSystemInfo.Exists)

--- a/Kudu.Services.Web/wwwroot/Content/Scripts/NavigateToInstance.js
+++ b/Kudu.Services.Web/wwwroot/Content/Scripts/NavigateToInstance.js
@@ -1,4 +1,4 @@
-(document).ready(function () {
+jQuery(document).ready(function () {
     $.ajax({
         type: "GET",
         url: '/instance/all',

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -213,13 +213,6 @@ namespace Kudu.Services.Deployment
             HttpContext context)
         {
 
-            var oryxManifestFile = Path.Combine(_environment.WebRootPath, "oryx-manifest.toml");
-            if (FileSystemHelpers.FileExists(oryxManifestFile))
-            {
-                _tracer.Step("Removing previous build artifact's manifest file");
-                FileSystemHelpers.DeleteFileSafe(oryxManifestFile);
-            }
-
             var zipFilePath = Path.Combine(_environment.ZipTempPath, Guid.NewGuid() + ".zip");
             if (_settings.RunFromLocalZip())
             {
@@ -227,6 +220,28 @@ namespace Kudu.Services.Deployment
             }
             else
             {
+                var oryxManifestFile = Path.Combine(_environment.WebRootPath, "oryx-manifest.toml");
+                if (FileSystemHelpers.FileExists(oryxManifestFile))
+                {
+                    _tracer.Step("Removing previous build artifact's manifest file");
+                    FileSystemHelpers.DeleteFileSafe(oryxManifestFile);
+                }
+
+                try
+                {
+                    var nodeModulesSymlinkFile = Path.Combine(_environment.WebRootPath, "node_modules");
+                    Mono.Unix.UnixSymbolicLinkInfo i = new Mono.Unix.UnixSymbolicLinkInfo(nodeModulesSymlinkFile);
+                    if (i.FileType == Mono.Unix.FileTypes.SymbolicLink)
+                    {
+                        _tracer.Step("Removing node_modules symlink");
+                        FileSystemHelpers.DeleteFileSafe(nodeModulesSymlinkFile);
+                    }
+                }
+                catch(Exception)
+                {
+
+                }
+
                 using (_tracer.Step("Writing zip file to {0}", zipFilePath))
                 {
                     if (!string.IsNullOrEmpty(context.Request.ContentType) &&

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -234,12 +234,14 @@ namespace Kudu.Services.Deployment
                     if (i.FileType == Mono.Unix.FileTypes.SymbolicLink)
                     {
                         _tracer.Step("Removing node_modules symlink");
-                        FileSystemHelpers.DeleteFileSafe(nodeModulesSymlinkFile);
+                        // TODO: Add support to remove Unix Symlink File in DeleteFileSafe
+                        // FileSystemHelpers.DeleteFileSafe(nodeModulesSymlinkFile); 
+                        FileSystemHelpers.RemoveUnixSymlink(nodeModulesSymlinkFile, TimeSpan.FromSeconds(5));
                     }
                 }
                 catch(Exception)
                 {
-
+                    // best effort
                 }
 
                 using (_tracer.Step("Writing zip file to {0}", zipFilePath))


### PR DESCRIPTION
This PR Fixes the deployments for Node 12.9 and accounts for removal of  symlinks if there is a zip deploy after git deploy. 