### PR TITLE
[ANT 88] Implement force remote build in Linux Consumption

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -161,7 +161,6 @@ namespace Kudu
         public const string WebSiteHomeStampName = "WEBSITE_HOME_STAMPNAME";
         public const string WebSiteStampDeploymentId = "WEBSITE_STAMP_DEPLOYMENT_ID";
         public const string MeshInitURI = "MESH_INIT_URI";
-        public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string KuduFileShareMountPath = "/kudu-mnt";
         public const string KuduFileSharePrefix = "kudu-mnt";
         public const string EnablePersistentStorage = "ENABLE_KUDU_PERSISTENT_STORAGE";

--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -137,11 +137,14 @@ namespace Kudu
         public const string FunctionKeyNewFormat = "~0.7";
         public const string FunctionRunTimeVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
+        public const string ScmRunFromPackageContainerName = "scm-releases";
+        public const string ScmRunFromPackageBlobPrefix = "rfp-latest";
         public const string WebSiteSku = "WEBSITE_SKU";
         public const string WebSiteElasticScaleEnabled = "WEBSITE_ELASTIC_SCALING_ENABLED";
         public const string DynamicSku = "Dynamic";
         public const string ElasticScaleEnabled = "1";
         public const string AzureWebJobsSecretStorageType = "AzureWebJobsSecretStorageType";
+        public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string HubName = "HubName";
         public const string DurableTaskStorageConnection = "connection";
         public const string DurableTaskStorageConnectionName = "azureStorageConnectionStringName";

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -76,5 +76,9 @@ namespace Kudu.Core.Deployment
         // If DoSyncTriggers is set to true, the after Linux Consumption function app deployment,
         // will initiate a POST request to http://appname.azurewebsites.net/admin/host/synctriggers
         public bool DoSyncTriggers { get; set; }
+
+        // This config is for Linux Consumption function app only
+        // Allow remote build even when WEBSITE_RUN_FROM_PACKAGE is set to a Url (RunFromRemoteZip)
+        public bool ForceRemoteBuild { get; set; }
     }
 }

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -78,7 +78,7 @@ namespace Kudu.Core.Deployment
         public bool DoSyncTriggers { get; set; }
 
         // This config is for Linux Consumption function app only
-        // Allow remote build even when WEBSITE_RUN_FROM_PACKAGE is set to a Url (RunFromRemoteZip)
-        public bool ForceRemoteBuild { get; set; }
+        // Allow artifact generation even when WEBSITE_RUN_FROM_PACKAGE is set to a Url (RunFromRemoteZip)
+        public bool OverwriteWebsiteRunFromPackage { get; set; }
     }
 }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -717,7 +717,7 @@ namespace Kudu.Core.Deployment
                                 settings: _settings,
                                 context: context,
                                 shouldSyncTriggers: deploymentInfo.DoSyncTriggers,
-                                shouldUpdateWebsiteRunFromPackage: deploymentInfo.ForceRemoteBuild);
+                                shouldUpdateWebsiteRunFromPackage: deploymentInfo.OverwriteWebsiteRunFromPackage);
                         }
 
                         await PostDeploymentHelper.SyncFunctionsTriggers(

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -712,7 +712,12 @@ namespace Kudu.Core.Deployment
                             // 1. packaging the output folder
                             // 2. upload the artifact to user's storage account
                             // 3. reset the container workers after deployment
-                            await LinuxConsumptionDeploymentHelper.SetupLinuxConsumptionFunctionAppDeployment(_environment, _settings, context, deploymentInfo.DoSyncTriggers);
+                            await LinuxConsumptionDeploymentHelper.SetupLinuxConsumptionFunctionAppDeployment(
+                                env: _environment,
+                                settings: _settings,
+                                context: context,
+                                shouldSyncTriggers: deploymentInfo.DoSyncTriggers,
+                                shouldUpdateWebsiteRunFromPackage: deploymentInfo.ForceRemoteBuild);
                         }
 
                         await PostDeploymentHelper.SyncFunctionsTriggers(

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -87,7 +87,9 @@ namespace Kudu.Core.Deployment
             
             // Else if this app is configured with a url in WEBSITE_USE_ZIP, then fail the deployment
             // since this is a RunFromZip site and the deployment has no chance of succeeding.
-            else if (_settings.RunFromRemoteZip())
+            // However, if this is a Linux Consumption function app, we allow KuduLite to change
+            // WEBSITE_RUN_FROM_PACKAGE app setting after a build finishes
+            else if (_settings.RunFromRemoteZip() && !deployInfo.ForceRemoteBuild)
             {
                 return FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured;
             }

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -89,7 +89,7 @@ namespace Kudu.Core.Deployment
             // since this is a RunFromZip site and the deployment has no chance of succeeding.
             // However, if this is a Linux Consumption function app, we allow KuduLite to change
             // WEBSITE_RUN_FROM_PACKAGE app setting after a build finishes
-            else if (_settings.RunFromRemoteZip() && !deployInfo.ForceRemoteBuild)
+            else if (_settings.RunFromRemoteZip() && !deployInfo.OverwriteWebsiteRunFromPackage)
             {
                 return FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured;
             }

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -410,8 +410,7 @@ namespace Kudu.Core.Helpers
 
             // Generate RemoveAllWorker request URI
             string baseUrl = $"http://{websiteHostname}/operations/removeworker/{sitename}/allStandard?token={authTokenEncoded}";
-            Uri baseUri = null;
-            if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out baseUri))
+            if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri baseUri))
             {
                 throw new ArgumentException($"Malformed URI is used in RemoveAllWorkers");
             }
@@ -424,8 +423,43 @@ namespace Kudu.Core.Helpers
                 Trace(TraceEventType.Information, "RemoveAllWorkers, statusCode = {0}", response.StatusCode);
                 response.EnsureSuccessStatusCode();
             }
-            
-            return;
+        }
+
+        /// <summary>
+        /// Update WEBSITE_RUN_FROM_PACKAGE to point to the latest blob
+        /// </summary>
+        /// <param name="blobSas">The unencrypted sas uri points to the destination blob</param>
+        /// <exception cref="ArgumentException">Thrown when SetRunFromPkg url is malformed.</exception>
+        /// <exception cref="HttpRequestException">Thrown when request to SetRunFromPkg is not OK.</exception>
+        public static async Task UpdateWebsiteRunFromPackage(string blobSas, DeploymentContext context)
+        {
+            // Generate URL encoded blobSas
+            string encryptedBlobSas = GetBlobSasEncryptedToken(blobSas);
+            string encryptedBlobSasEncoded = HttpUtility.UrlEncode(encryptedBlobSas);
+
+            // Generate web request protocol
+            string protocol = Environment.SkipSslValidation ? "http" : "https";
+
+            // Generate update app setting request
+            string baseUrl = $"{protocol}://{HttpHost}/operations/set-run-from-pkg?run-from-pkg-path={encryptedBlobSasEncoded}";
+            if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri baseUri))
+            {
+                throw new ArgumentException($"Malformed URI is used in SetRunFromPkg");
+            }
+
+            // Initiate web request
+            Trace(TraceEventType.Information, "Calling scm SetRunFromPkg to update WEBSITE_RUN_FROM_PACKAGE for the function app");
+            using (var client = HttpClientFactory())
+            using (var request = new HttpRequestMessage(HttpMethod.Post, baseUri))
+            {
+                request.Headers.Add(Constants.SiteRestrictedToken, GetWebsiteAuthToken());
+                using (var response = await client.SendAsync(request))
+                {
+                    Trace(TraceEventType.Information, "SetRunFromPkg, statusCode = {0}", response.StatusCode);
+                    context.Logger.Log($"response.StatusCode = {response.StatusCode}");
+                    response.EnsureSuccessStatusCode();
+                }
+            }
         }
 
         /// <summary>
@@ -461,6 +495,12 @@ namespace Kudu.Core.Helpers
             string websiteAuthEncryptionKey = System.Environment.GetEnvironmentVariable(SettingsKeys.AuthEncryptionKey);
             DateTime expiry = DateTime.UtcNow.AddMinutes(5);
             return SimpleWebTokenHelper.CreateToken(expiry, websiteAuthEncryptionKey.ToKeyBytes());
+        }
+
+        private static string GetBlobSasEncryptedToken(string blobSas)
+        {
+            string websiteAuthEncryptionKey = System.Environment.GetEnvironmentVariable(SettingsKeys.AuthEncryptionKey);
+            return SimpleWebTokenHelper.CreateEncryptedBlobSas(blobSas, websiteAuthEncryptionKey.ToKeyBytes());
         }
 
         private static void VerifyEnvironments()

--- a/Kudu.Core/Helpers/SimpleWebTokenHelper.cs
+++ b/Kudu.Core/Helpers/SimpleWebTokenHelper.cs
@@ -20,6 +20,8 @@ namespace Kudu.Core.Helpers
         /// <param name="key">Optional key to encrypt the token with</param>
         /// <returns>a SWT signed by this app</returns>
         public static string CreateToken(DateTime validUntil, byte[] key = null) => Encrypt($"exp={validUntil.Ticks}", key);
+        public static string CreateEncryptedBlobSas(string blobSas, byte[] key = null) => Encrypt(blobSas, key);
+
          [SuppressMessage("Microsoft.Usage", "CA2202:Object 'cipherStream' and 'cryptoStream' can be disposed mo re than once",
             Justification = "MemoeryStream, CryptoStream, and BinaryWriter handle multiple disposal correctly. The alternative is pretty ugly code for clearing each variable, checking for null, and manual dispose.")]
         public static string Encrypt(string value, byte[] key = null)

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -55,6 +55,7 @@ namespace Kudu.Services.Deployment
         public async Task<IActionResult> ZipPushDeploy(
             [FromQuery] bool isAsync = false,
             [FromQuery] bool syncTriggers = false,
+            [FromQuery] bool forceRemoteBuild = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -79,7 +80,8 @@ namespace Kudu.Services.Deployment
                     AuthorEmail = authorEmail,
                     Message = message,
                     ZipURL = null,
-                    DoSyncTriggers = syncTriggers
+                    DoSyncTriggers = syncTriggers,
+                    ForceRemoteBuild = forceRemoteBuild && _environment.IsOnLinuxConsumption
                 };
 
                 if (_settings.RunFromLocalZip())
@@ -103,6 +105,7 @@ namespace Kudu.Services.Deployment
             [FromBody] JObject requestJson,
             [FromQuery] bool isAsync = false,
             [FromQuery] bool syncTriggers = false,
+            [FromQuery] bool forceRemoteBuild = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -129,7 +132,8 @@ namespace Kudu.Services.Deployment
                     AuthorEmail = authorEmail,
                     Message = message,
                     ZipURL = zipUrl,
-                    DoSyncTriggers = syncTriggers
+                    DoSyncTriggers = syncTriggers,
+                    ForceRemoteBuild = forceRemoteBuild && _environment.IsOnLinuxConsumption
                 };
                 return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
             }

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -55,7 +55,7 @@ namespace Kudu.Services.Deployment
         public async Task<IActionResult> ZipPushDeploy(
             [FromQuery] bool isAsync = false,
             [FromQuery] bool syncTriggers = false,
-            [FromQuery] bool forceRemoteBuild = false,
+            [FromQuery] bool overwriteWebsiteRunFromPackage = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -81,7 +81,7 @@ namespace Kudu.Services.Deployment
                     Message = message,
                     ZipURL = null,
                     DoSyncTriggers = syncTriggers,
-                    ForceRemoteBuild = forceRemoteBuild && _environment.IsOnLinuxConsumption
+                    OverwriteWebsiteRunFromPackage = overwriteWebsiteRunFromPackage && _environment.IsOnLinuxConsumption
                 };
 
                 if (_settings.RunFromLocalZip())
@@ -105,7 +105,7 @@ namespace Kudu.Services.Deployment
             [FromBody] JObject requestJson,
             [FromQuery] bool isAsync = false,
             [FromQuery] bool syncTriggers = false,
-            [FromQuery] bool forceRemoteBuild = false,
+            [FromQuery] bool overwriteWebsiteRunFromPackage = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
             [FromQuery] string deployer = DefaultDeployer,
@@ -133,7 +133,7 @@ namespace Kudu.Services.Deployment
                     Message = message,
                     ZipURL = zipUrl,
                     DoSyncTriggers = syncTriggers,
-                    ForceRemoteBuild = forceRemoteBuild && _environment.IsOnLinuxConsumption
+                    OverwriteWebsiteRunFromPackage = overwriteWebsiteRunFromPackage && _environment.IsOnLinuxConsumption
                 };
                 return await PushDeployAsync(deploymentInfo, isAsync, HttpContext);
             }


### PR DESCRIPTION
This change is released in mcr.microsoft.com/azure-functions/kudulite:kudu-2.11 for Linux Consumption

This is a change for Linux Consumption, since we previously introduce remote build with the hidden app setting SCM_RUN_FROM_PACKAGE, it confuses our user.

We now accepts api/zipdeploy?forceremotebuild=true to override the WEBSITE_RUN_FROM_PACKAGE app setting, which generalize the run from package scenarios, bringing Linux Consumption and Linux App Service plan onto the same ground.

The forceremotebuild performs two things:
1. It allows zipdeploy even when WEBSITE_RUN_FROM_PACKAGE is set to a URL in Linux Consumption
2. It will call scm/operations/set-run-from-pkg in the Controller to make WEBSITE_RUN_FROM_PACKAGE app setting point to the latest function app artifact