### PR TITLE
Fix Log4Net config for KuduConsole telemetry

### DIFF
--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -23,18 +23,24 @@ using Kudu.Core.Tracing;
 using System.Reflection;
 using Kudu.Core.LinuxConsumption;
 using XmlSettings;
-using log4net;
-using log4net.Config;
+using System.Xml;
 
 namespace Kudu.Console
 {
     internal class Program
     {
-        
+
         private static int Main(string[] args)
         {
-            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            XmlConfigurator.Configure(logRepository, new FileInfo("log4net.config"));
+            // Configure Logging if running on Azure
+            if (System.Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") != null)
+            {
+                XmlDocument log4netConfig = new XmlDocument();
+                log4netConfig.Load(File.OpenRead("/opt/Kudu/KuduConsole/log4net.config"));
+                var repo = log4net.LogManager.CreateRepository(Assembly.GetEntryAssembly(),
+                    typeof(log4net.Repository.Hierarchy.Hierarchy));
+                log4net.Config.XmlConfigurator.Configure(repo, log4netConfig["log4net"]);
+            }
 
             // Turn flag on in app.config to wait for debugger on launch
             if (ConfigurationManager.AppSettings["WaitForDebuggerOnStart"] == "true")
@@ -80,7 +86,7 @@ namespace Kudu.Console
             string deploymentLockPath = Path.Combine(lockPath, Constants.DeploymentLockFile);
 
             IOperationLock deploymentLock = DeploymentLockFile.GetInstance(deploymentLockPath, traceFactory);
-            
+
             if (deploymentLock.IsHeld)
             {
                 return PerformDeploy(appRoot, wapTargets, deployer, lockPath, env, settingsManager, level, tracer, traceFactory, deploymentLock);
@@ -127,10 +133,10 @@ namespace Kudu.Console
             string statusLockPath = Path.Combine(lockPath, Constants.StatusLockFile);
             string hooksLockPath = Path.Combine(lockPath, Constants.HooksLockFile);
 
-            
+
             IOperationLock statusLock = new LockFile(statusLockPath, traceFactory);
             IOperationLock hooksLock = new LockFile(hooksLockPath, traceFactory);
-            
+
             IBuildPropertyProvider buildPropertyProvider = new BuildPropertyProvider();
             ISiteBuilderFactory builderFactory = new SiteBuilderFactory(buildPropertyProvider, env);
             var logger = new ConsoleLogger();
@@ -205,7 +211,7 @@ namespace Kudu.Console
                 finally
                 {
                     System.Console.WriteLine("Deployment Logs : '"+
-                        env.AppBaseUrlPrefix+ "/newui/jsonviewer?view_url=/api/deployments/" + 
+                        env.AppBaseUrlPrefix+ "/newui/jsonviewer?view_url=/api/deployments/" +
                         gitRepository.GetChangeSet(settingsManager.GetBranch()).Id+"/log'");
                 }
             }
@@ -263,11 +269,11 @@ namespace Kudu.Console
         {
             string root = Path.GetFullPath(Path.Combine(siteRoot, ".."));
 
-            // CORE TODO : test by setting SCM_REPOSITORY_PATH 
+            // CORE TODO : test by setting SCM_REPOSITORY_PATH
             // REVIEW: this looks wrong because it ignores SCM_REPOSITORY_PATH
             string repositoryPath = Path.Combine(siteRoot, Constants.RepositoryPath);
 
-            // SCM_BIN_PATH is introduced in Kudu apache config file 
+            // SCM_BIN_PATH is introduced in Kudu apache config file
             // Provide a way to override Kudu bin path, to resolve issue where we can not find the right Kudu bin path when running on mono
             // CORE TODO I don't think this is needed anymore? This env var is not used anywhere but here.
             string binPath = System.Environment.GetEnvironmentVariable("SCM_BIN_PATH");

--- a/Kudu.Console/log4net.config
+++ b/Kudu.Console/log4net.config
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <log4net>
-    <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender,log4net">
-        <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
-        <file type="log4net.Util.PatternString" value="/var/log/kudulogs/%utcdate{yyyy-MM-dd}_%env{COMPUTERNAME}_scm_console_docker.log" />
-        <param name="RollingStyle" value="Size"/>
-        <param name="StaticLogFileName" value="true"/>
-        <appendToFile value="true" />
-        <maxSizeRollBackups value="10"/>
-        <maximumFileSize value="5MB"/>
-        <layout type="log4net.Layout.PatternLayout">
-            <conversionPattern value="%date{yyyy-MM-dd-HH:mm:ss.fff} %message%n" />
-        </layout>
-    </appender>
-    <root>
-        <level value="ALL"/>
-        <appender-ref ref="RollingLogFileAppender"/>
-    </root>
+  <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender,log4net">
+    <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
+    <file type="log4net.Util.PatternString" value="/var/log/kudulogs/%utcdate{yyyy-MM-dd}_%env{COMPUTERNAME}_scm_console_docker.log" />
+    <param name="RollingStyle" value="Size"/>
+    <param name="StaticLogFileName" value="true"/>
+    <appendToFile value="true" />
+    <maxSizeRollBackups value="10"/>
+    <maximumFileSize value="5MB"/>
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date{yyyy-MM-dd-HH:mm:ss.fff} %message%n" />
+    </layout>
+  </appender>
+  <root>
+    <level value="ALL"/>
+    <appender-ref ref="RollingLogFileAppender"/>
+  </root>
 </log4net>


### PR DESCRIPTION
There was a bug in loading the Log4Net config for KuduConsole which didn't produce structured logs. Defaulting this config to use absolute path instead.