### PR TITLE
Log events with actual sitename in Linux LinuxConsumption

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -118,6 +118,7 @@ namespace Kudu
         //Setting for VC++ for node builds
         public const string VCVersion = "2015";
 
+        public const string WebsiteSiteName = "WEBSITE_SITE_NAME";
         public const string SiteRestrictedToken = "x-ms-site-restricted-token";
         public const string SiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string HttpHost = "HTTP_HOST";

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -145,7 +145,7 @@ namespace Kudu.Console
                 gitRepository = new GitExeRepository(env, settingsManager, traceFactory);
             }
 
-            IServerConfiguration serverConfiguration = new ServerConfiguration();
+            IServerConfiguration serverConfiguration = new ServerConfiguration(SystemEnvironment.Instance);
             IAnalytics analytics = new Analytics(settingsManager, serverConfiguration, traceFactory);
 
             IWebHooksManager hooksManager = new WebHooksManager(tracer, env, hooksLock);

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -11,6 +11,7 @@ using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Helpers;
 using Kudu.Core.Hooks;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.LinuxConsumption;
 using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 
@@ -328,7 +329,7 @@ namespace Kudu.Core.Deployment
                     var hooksLock = new LockFile(hooksLockPath, traceFactory);
                     var deploymentLock = DeploymentLockFile.GetInstance(deploymentLockPath, traceFactory);
 
-                    var analytics = new Analytics(settings, new ServerConfiguration(), traceFactory);
+                    var analytics = new Analytics(settings, new ServerConfiguration(SystemEnvironment.Instance), traceFactory);
                     var deploymentStatusManager = new DeploymentStatusManager(environment, analytics, statusLock);
                     var siteBuilderFactory = new SiteBuilderFactory(new BuildPropertyProvider(), environment);
                     var webHooksManager = new WebHooksManager(tracer, environment, hooksLock);

--- a/Kudu.Core/Jobs/JobLogger.cs
+++ b/Kudu.Core/Jobs/JobLogger.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Abstractions;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.LinuxConsumption;
 using Kudu.Core.Tracing;
 using Newtonsoft.Json;
 
@@ -36,7 +37,7 @@ namespace Kudu.Core.Jobs
             _statusFileName = statusFileName;
             TraceFactory = traceFactory;
             Environment = environment;
-            Analytics = new Analytics(null, new ServerConfiguration(), traceFactory);
+            Analytics = new Analytics(null, new ServerConfiguration(SystemEnvironment.Instance), traceFactory);
 
             InstanceId = InstanceIdUtility.GetShortInstanceId();
         }

--- a/Kudu.Core/LinuxConsumption/MeshPersistentFileSystem.cs
+++ b/Kudu.Core/LinuxConsumption/MeshPersistentFileSystem.cs
@@ -48,11 +48,6 @@ namespace Kudu.Core.LinuxConsumption
             return !string.IsNullOrWhiteSpace(connectionString);
         }
 
-        private bool IsLinuxConsumption()
-        {
-            return !string.IsNullOrEmpty(_environment.GetEnvironmentVariable(Constants.ContainerName));
-        }
-
         private bool IsKuduShareMounted()
         {
             return _fileShareMounted;
@@ -80,7 +75,7 @@ namespace Kudu.Core.LinuxConsumption
                 return true;
             }
 
-            if (!IsLinuxConsumption())
+            if (!_environment.IsOnLinuxConsumption())
             {
                 const string message =
                     "Mounting kudu file share is only supported on Linux consumption environment";
@@ -125,7 +120,7 @@ namespace Kudu.Core.LinuxConsumption
         {
             if (_fileShareMounted)
             {
-                return Path.Combine(Constants.KuduFileShareMountPath, "deployments");
+                return Path.Combine(Constants.KuduFileShareMountPath, Constants.DeploymentCachePath);
             }
 
             return null;

--- a/Kudu.Core/LinuxConsumption/SystemEnvironmentExtensions.cs
+++ b/Kudu.Core/LinuxConsumption/SystemEnvironmentExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Kudu.Core.LinuxConsumption
+{
+    public static class SystemEnvironmentExtensions
+    {
+        public static bool IsOnLinuxConsumption(this ISystemEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(Constants.ContainerName));
+        }
+    }
+}

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -50,7 +50,6 @@ namespace Kudu.Services.Web
         private readonly IHostingEnvironment _hostingEnvironment;
         private IEnvironment _webAppRuntimeEnvironment;
         private IDeploymentSettingsManager _noContextDeploymentsSettingsManager;
-        private static readonly ServerConfiguration ServerConfiguration = new ServerConfiguration();
 
         public Startup(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
         {
@@ -180,7 +179,7 @@ namespace Kudu.Services.Web
             services.AddLinuxConsumptionAuthorization(environment);
 
             // General
-            services.AddSingleton<IServerConfiguration>(ServerConfiguration);
+            services.AddSingleton<IServerConfiguration, ServerConfiguration>();
 
             // CORE TODO Looks like this doesn't ever actually do anything, can refactor out?
             services.AddSingleton<IBuildPropertyProvider>(new BuildPropertyProvider());

--- a/Kudu.Tests/LinuxConsumption/ServerConfigurationTests.cs
+++ b/Kudu.Tests/LinuxConsumption/ServerConfigurationTests.cs
@@ -1,0 +1,25 @@
+﻿using Kudu.Core.Infrastructure;
+using Xunit;
+
+namespace Kudu.Tests.LinuxConsumption
+{
+    [Collection("MockedEnvironmentVariablesCollection")]
+    public class ServerConfigurationTests
+    {
+        [Fact]
+        public void ReturnsApplicationName()
+        {
+            var testSystemEnvironment = new TestSystemEnvironment();
+            const string placeholderSiteName = "placeholder-site-name";
+            testSystemEnvironment.SetEnvironmentVariable(Constants.ContainerName, "c1"); // linux consumption
+            testSystemEnvironment.SetEnvironmentVariable(Constants.WebsiteSiteName, placeholderSiteName);
+            var serverConfiguration = new ServerConfiguration(testSystemEnvironment);
+            Assert.Equal(placeholderSiteName, serverConfiguration.ApplicationName);
+
+            // Updating the env variable should reflect immediately. since sitename is not cached
+            const string testSite2 = "test-site-2";
+            testSystemEnvironment.SetEnvironmentVariable(Constants.WebsiteSiteName, testSite2);
+            Assert.Equal(testSite2, serverConfiguration.ApplicationName);
+        }
+    }
+}


### PR DESCRIPTION
Since Linux consumption containers start in placeholdermode the initially cached sitename should be refreshed once the container is specialized