### PR TITLE
DynamicInstall Post-Recieve Hook Fix

### DIFF
--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -9,7 +9,7 @@ namespace Kudu.Core.Deployment
 {
     public class DeploymentStatusManager : IDeploymentStatusManager
     {
-        public static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(30);
         private readonly IEnvironment _environment;
         private readonly IAnalytics _analytics;
         private readonly IOperationLock _statusLock;

--- a/Kudu.Core/Helpers/EnvironmentHelper.cs
+++ b/Kudu.Core/Helpers/EnvironmentHelper.cs
@@ -23,7 +23,13 @@ namespace Kudu.Core.Helpers
 
             return binPath;
         }
-        
+
+        public static bool IsDynamicInstallEnvironment()
+        {
+            var dynEnvVarValue = System.Environment.GetEnvironmentVariable("DYNAMIC_INSTALL_ENABLED");
+            return dynEnvVarValue != null && string.Equals(dynEnvVarValue, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
         // Is this a Windows Containers site?
         public static bool IsWindowsContainers()
         {

--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -62,7 +62,7 @@ namespace Kudu.Core.SourceControl.Git
         public RepositoryType RepositoryType
         {
             get { return RepositoryType.Git; }
-        } 
+        }
 
         public bool SkipPostReceiveHookCheck
         {
@@ -185,7 +185,17 @@ fi" + "\n";
                     sb.AppendLine("#!/bin/sh");
                     sb.AppendLine("read i");
                     sb.AppendLine("echo $i > pushinfo");
-                    sb.AppendLine(KnownEnvironment.KUDUCOMMAND);
+
+
+                    if (EnvironmentHelper.IsDynamicInstallEnvironment())
+                    {
+                        sb.AppendLine(KnownEnvironment.KUDUCOMMAND_DYNAMICINSTALL);
+                    }
+                    else
+                    {
+                        sb.AppendLine(KnownEnvironment.KUDUCOMMAND);
+                    }
+
                     if (OSDetector.IsOnWindows())
                     {
                         FileSystemHelpers.WriteAllText(PostReceiveHookPath, sb.ToString());

--- a/Kudu.Core/SourceControl/Git/KnownEnvironment.cs
+++ b/Kudu.Core/SourceControl/Git/KnownEnvironment.cs
@@ -18,5 +18,13 @@ namespace Kudu.Core.SourceControl.Git
                                            "\"$" + APPPATH + "\" " +
                                            "\"$" + MSBUILD + "\" " +
                                            "\"$" + DEPLOYER + "\"";
+
+        // Command to launch the post receive hook for dynamic install
+        // CORE NOTE modified the script to run "dotnet," assuming EXEPATH points
+        // to a framework-dependent Core app.
+        public static string KUDUCOMMAND_DYNAMICINSTALL = "dotnet \"$" + EXEPATH + "\" " +
+                                           "\"$" + APPPATH + "\" " +
+                                           "\"$" + MSBUILD + "\" " +
+                                           "\"$" + DEPLOYER + "\"";
     }
 }

--- a/Kudu.Core/SourceControl/Git/LibGit2SharpRepository.cs
+++ b/Kudu.Core/SourceControl/Git/LibGit2SharpRepository.cs
@@ -105,10 +105,20 @@ fi" + "\n";
                 {
                     FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(PostReceiveHookPath));
 
+                    var command = "";
+                    if(EnvironmentHelper.IsDynamicInstallEnvironment())
+                    {
+                        command = KnownEnvironment.KUDUCOMMAND_DYNAMICINSTALL;
+                    }
+                    else
+                    {
+                        command = KnownEnvironment.KUDUCOMMAND;
+                    }
+
                     var content = @"#!/bin/sh
 read i
 echo $i > pushinfo
-" + KnownEnvironment.KUDUCOMMAND + "\r\n";
+" + command + "\r\n";
 
                     File.WriteAllText(PostReceiveHookPath, content);
                 }
@@ -157,9 +167,9 @@ echo $i > pushinfo
 
                 foreach(var change in changes)
                 {
-                    repo.Index.Add(change);                    
+                    repo.Index.Add(change);
                 }
-                
+
                 if (string.IsNullOrWhiteSpace(authorName) ||
                     string.IsNullOrWhiteSpace(emailAddress))
                 {
@@ -172,7 +182,7 @@ echo $i > pushinfo
                 {
                     var author = new Signature(authorName, emailAddress, DateTimeOffset.UtcNow);
                     var committer = author;
-                    
+
                     repo.Commit(message, author, committer);
                 }
                 return true;
@@ -245,7 +255,7 @@ echo $i > pushinfo
                             LibGit2Sharp.Commands.Fetch(repo, currRemote.Name, refSpecs, null, logMessage);
                         }
                     }
-                    
+
                     using (tracer.Step("LibGit2SharpRepository Update"))
                     {
                         // Are we fetching a tag?
@@ -373,13 +383,13 @@ echo $i > pushinfo
             using (var repo = new LibGit2Sharp.Repository(RepositoryPath))
             {
                 var files = repo.Diff.Compare<TreeChanges>(
-                        repo.Head.Tip.Tree, 
-                        null, 
-                        lookupList, 
+                        repo.Head.Tip.Tree,
+                        null,
+                        lookupList,
                         new CompareOptions() { IncludeUnmodified = true, Similarity = SimilarityOptions.None })
                     .Select(d => Path.Combine(repo.Info.WorkingDirectory, d.Path))
                     .Where(p => p.StartsWith(path, StringComparison.OrdinalIgnoreCase));
-                
+
                 /*
                 var files = repo.Diff.Compare<TreeChanges>(null, DiffTargets.Index, lookupList, compareOptions: new CompareOptions() { IncludeUnmodified = true, Similarity = SimilarityOptions.None })
                                       .Select(d => Path.Combine(repo.Info.WorkingDirectory, d.Path))

--- a/Kudu.Core/SourceControl/NullRepository.cs
+++ b/Kudu.Core/SourceControl/NullRepository.cs
@@ -67,7 +67,9 @@ namespace Kudu.Core.SourceControl
                 }
             }
 
-            throw new InvalidOperationException();
+            // Mark a null commit, and continue the deployment
+            Commit(null, null, null);
+            return _latestChangeSet;
         }
 
         public void AddFile(string path)

--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -42,36 +42,36 @@ namespace Kudu.Services.Web
         // This method initializes status,ssh,hooks & deployment locks used by Kudu to ensure
         // synchronized operations. This method creates a dictionary of locks which is injected
         // into various controllers to resolve the locks they need.
-        // <list type="bullet">  
-        //     <listheader>  
-        //         <term>Locks used by Kudu:</term>  
-        //     </listheader>  
-        //     <item>  
-        //         <term>Status Lock</term>  
-        //         <description>Used by DeploymentStatusManager</description>  
-        //     </item> 
-        //     <item>  
-        //         <term>SSH Lock</term>  
-        //         <description>Used by SSHKeyController</description>  
-        //     </item> 
-        //     <item>  
-        //         <term>Hooks Lock</term>  
-        //         <description>Used by WebHooksManager</description>  
-        //     </item> 
-        //     <item>  
-        //         <term>Deployment Lock</term>  
+        // <list type="bullet">
+        //     <listheader>
+        //         <term>Locks used by Kudu:</term>
+        //     </listheader>
+        //     <item>
+        //         <term>Status Lock</term>
+        //         <description>Used by DeploymentStatusManager</description>
+        //     </item>
+        //     <item>
+        //         <term>SSH Lock</term>
+        //         <description>Used by SSHKeyController</description>
+        //     </item>
+        //     <item>
+        //         <term>Hooks Lock</term>
+        //         <description>Used by WebHooksManager</description>
+        //     </item>
+        //     <item>
+        //         <term>Deployment Lock</term>
         //         <description>
-        //             Used by DeploymentController, DeploymentManager, SettingsController, 
+        //             Used by DeploymentController, DeploymentManager, SettingsController,
         //             FetchDeploymentManager, LiveScmController, ReceivePackHandlerMiddleware
-        //         </description>  
-        //     </item> 
-        // </list>  
+        //         </description>
+        //     </item>
+        // </list>
         // </summary>
         // <remarks>
         //     Uses File watcher.
         //     This originally used Ninject's "WhenInjectedInto" in .Net project for specific instances. IServiceCollection
-        //     doesn't support this concept, or anything similar like named instances. There are a few possibilities, 
-        //     but the hack solution for now is just injecting a dictionary of locks and letting each dependent resolve 
+        //     doesn't support this concept, or anything similar like named instances. There are a few possibilities,
+        //     but the hack solution for now is just injecting a dictionary of locks and letting each dependent resolve
         //     the one it needs.
         // </remarks>
         private static void SetupLocks(ITraceFactory traceFactory, IEnvironment environment)
@@ -106,7 +106,7 @@ namespace Kudu.Services.Web
 
             // Create deployment logs directory if it doesn't exist
             FileSystemHelpers.CreateDirectory(fileDirectoryPath);
-            
+
             // Set up custom content types - associating file extension to MIME type
             var provider = new FileExtensionContentTypeProvider
             {
@@ -216,18 +216,30 @@ namespace Kudu.Services.Web
             {
                 var fileText = FileSystemHelpers.ReadAllText(gitPostReceiveHookFile);
                 var isRunningOnAzure = System.Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") != null;
-                if (fileText.Contains("/usr/bin/mono"))
+
+                if(!EnvironmentHelper.IsDynamicInstallEnvironment())
                 {
-                    if(isRunningOnAzure)
+                    if (fileText.Contains("/usr/bin/mono"))
                     {
-                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("/usr/bin/mono", "benv dotnet=2.2 dotnet"));
+                        if (isRunningOnAzure)
+                        {
+                            FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("/usr/bin/mono", "benv dotnet=2.2 dotnet"));
+                        }
+                    }
+                    else if (!fileText.Contains("benv") && fileText.Contains("dotnet") && isRunningOnAzure)
+                    {
+                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("dotnet", "benv dotnet=2.2 dotnet"));
                     }
                 }
-                else if(!fileText.Contains("benv") && fileText.Contains("dotnet") && isRunningOnAzure)
+                else
                 {
-                    FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("dotnet", "benv dotnet=2.2 dotnet"));
+                    // Dynamic Install should just contain dotnet
+                    if (fileText.Contains("benv") && fileText.Contains("dotnet") && isRunningOnAzure)
+                    {
+                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("benv dotnet=2.2", "dotnet"));
+                    }
                 }
-                
+
             }
 
             if (FileSystemHelpers.DirectoryExists(Path.Combine(environment.RootPath, ".mono"))
@@ -270,7 +282,7 @@ namespace Kudu.Services.Web
         internal static ITracer GetTracerWithoutContext(IEnvironment environment, IDeploymentSettingsManager settings)
         {
             // when file system has issue, this can throw (environment.TracePath calls EnsureDirectory).
-            // prefer no-op tracer over outage.  
+            // prefer no-op tracer over outage.
             return OperationManager.SafeExecute(() =>
             {
                 var traceLevel = settings.GetTraceLevel();
@@ -344,7 +356,7 @@ namespace Kudu.Services.Web
         /// corrupt settings.xml file
         /// </summary>
         /// <param name="environment">
-        /// IEnvironment object that maintains paths used by kudu 
+        /// IEnvironment object that maintains paths used by kudu
         /// </param>
         internal static void EnsureValidDeploymentXmlSettings(IEnvironment environment)
         {
@@ -437,7 +449,7 @@ namespace Kudu.Services.Web
         }
 
         /// <summary>
-        /// Sets the environment variables for Net Core CLI. 
+        /// Sets the environment variables for Net Core CLI.
         /// </summary>
         /// <remarks>
         /// This method previously included environment variables to optimize net core runtime to run in a container.
@@ -483,7 +495,7 @@ namespace Kudu.Services.Web
 
         /// <summary>
         /// Returns a dictionary containing references to all the singleton lock objects. Initialises these locks
-        /// if they have not been initialised 
+        /// if they have not been initialised
         /// </summary>
         /// <param name="traceFactory"></param>
         /// <param name="environment"></param>

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -20,6 +20,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Collections.Generic;
 using Kudu.Core.Helpers;
+using System.Threading;
 
 namespace Kudu.Services.Deployment
 {
@@ -446,6 +447,7 @@ namespace Kudu.Services.Deployment
             // least 1 commit in the IRepository. Even though there is no repo per se in this
             // scenario, deployment pipeline still generates a NullRepository
             repository.Commit(zipDeploymentInfo.Message, zipDeploymentInfo.Author, zipDeploymentInfo.AuthorEmail);
+            Thread.Sleep(2000);
         }
 
         private static void CreateZipSymlinks(IDictionary<string, string> symLinks, string extractTargetDirectory)


### PR DESCRIPTION
This PR bypasses the use of `benv` for Kudu Dynamic Install. It sets git `post-recieve` hooks to directly use `dotnet`, this aligns with plans to migrate Kudu to `ASP NETCore 3.1` where latest dotnet could be called by simply invoking `dotnet`