### PR TITLE
Adding --compress-destination-dir for Python builds

### DIFF
--- a/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
@@ -49,7 +49,7 @@ namespace Kudu.Core.Deployment
             // Parse Build Flags
             Flags = BuildFlagsHelper.Parse(buildFlags);
 
-            // Set language specific 
+            // Set language specific
             SetLanguageOptions();
         }
 
@@ -246,7 +246,7 @@ namespace Kudu.Core.Deployment
                     }
                     else if (Language == Framework.Python)
                     {
-                        OryxArgumentsHelper.AddPythonCompressOption(args, "tar-gz");
+                        OryxArgumentsHelper.AddPythonCompressOption(args);
                     }
 
                     break;
@@ -259,7 +259,7 @@ namespace Kudu.Core.Deployment
                     }
                     else if (Language == Framework.Python)
                     {
-                        OryxArgumentsHelper.AddPythonCompressOption(args, "zip");
+                        OryxArgumentsHelper.AddPythonCompressOption(args);
                     }
 
                     break;

--- a/Kudu.Core/Deployment/Oryx/OryxArgumentsHelper.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxArgumentsHelper.cs
@@ -31,9 +31,9 @@ namespace Kudu.Core.Deployment.Oryx
             args.AppendFormat(" -p compress_node_modules={0}", format);
         }
 
-        internal static void AddPythonCompressOption(StringBuilder args, string format)
+        internal static void AddPythonCompressOption(StringBuilder args)
         {
-            args.AppendFormat(" -p compress_virtualenv={0}", format);
+            args.Append(" --compress-destination-dir");
         }
 
         internal static void AddPythonVirtualEnv(StringBuilder args, string virtualEnv)


### PR DESCRIPTION
Added _--compress-destination-dir_ flag for Oryx build commands for python.
Removed _-p compress_virtualenv={0}_ as this is no longer needed.