### PR TITLE
Fail update status API silently if 3 retries fail

### DIFF
--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -321,7 +321,9 @@ namespace Kudu.Core.Deployment
             catch (Exception ex)
             {
                 _tracer.TraceError($"Failed to request a post deployment status. Number of attempts: {attemptCount}. Exception: {ex}");
-                throw;
+                // Do not throw the exception
+                // We fail silently so that we do not fail the build altogether if this call fails
+                //throw;
             }
         }
 

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -642,11 +642,11 @@ namespace Kudu.Core.Helpers
             }
             catch (HttpRequestException ex)
             {
-                if (path.Equals(Constants.UpdateDeployStatusPath, StringComparison.OrdinalIgnoreCase))
+                if (path.Equals(Constants.UpdateDeployStatusPath, StringComparison.OrdinalIgnoreCase) && statusCode == HttpStatusCode.NotFound)
                 {
-                    // Fail silently if call to update dpeloyment status fails.
-                    // This makes sure we do not fail the build if this call fails
-                    Trace(TraceEventType.Warning, $"Call to {path} ended in an exception. {ex}");
+                    // Fail silently if 404 is encountered.
+                    // This will only happen transiently during a platform upgrade if new bits aren't on the FrontEnd yet.
+                    Trace(TraceEventType.Warning, $"Call to {path} ended in 404. {ex}");
                 }
                 else
                 {


### PR DESCRIPTION
Re-structuring the silent fail logic in case call to update status api fails. 
Incase 3 retries fail, we log the exception and move on without throwing it onto the caller which might cause a build failure. This takes care of retrying 3 times in case of throttling kicks in.

If we keep logic inside of PostAsync to fail silently, we will not retry 3 times when we throttle.