### PR TITLE
Improve Deployment Tracing

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -57,6 +57,8 @@ namespace Kudu
 
         public const string DummyRazorExtension = ".kudu777";
 
+        public const string ScmDeploymentKind = "ScmDeploymentKind";
+
         // Kudu trace text file related
         public const string DeploymentTracePath = LogFilesPath + @"/kudu/deployment";
 

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -42,6 +42,9 @@ namespace Kudu.Console
                 log4net.Config.XmlConfigurator.Configure(repo, log4netConfig["log4net"]);
             }
 
+            // signify the deployment is done by git push
+            System.Environment.SetEnvironmentVariable(Constants.ScmDeploymentKind, "GitPush");
+
             // Turn flag on in app.config to wait for debugger on launch
             if (ConfigurationManager.AppSettings["WaitForDebuggerOnStart"] == "true")
             {

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -406,6 +406,9 @@ namespace Kudu.Core.Deployment
 
             // Cleaup old deployments
             PurgeAndGetDeployments();
+
+            // Report deployment completion
+            DeploymentCompletedInfo.Persist(_environment.RequestId, status, _analytics);
         }
 
         // since the expensive part (reading all files) is done,

--- a/Kudu.Core/Helpers/DeploymentCompletedInfo.cs
+++ b/Kudu.Core/Helpers/DeploymentCompletedInfo.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using Newtonsoft.Json;
+
+namespace Kudu.Core.Helpers
+{
+    public class DeploymentCompletedInfo
+    {
+        public const string LatestDeploymentFile = "LatestDeployment.json";
+
+        public string TimeStamp { get; set; }
+        public string SiteName { get; set; }
+        public string RequestId { get; set; }
+        public string Kind { get; set; }
+        public string Status { get; set; }
+        public string Details { get; set; }
+
+        private static IAnalytics _analytics;
+
+        public static void Persist(string requestId, IDeploymentStatusFile status, IAnalytics analytics)
+        {
+            // signify the deployment is done by git push
+            var kind = System.Environment.GetEnvironmentVariable(Constants.ScmDeploymentKind);
+            if (string.IsNullOrEmpty(kind))
+            {
+                kind = status.Deployer;
+            }
+            _analytics = analytics;
+            var serializedStatus = JsonConvert.SerializeObject(status, Formatting.Indented);
+            Persist(status.SiteName, kind, requestId, status.Status.ToString(), serializedStatus);
+        }
+
+        public static void Persist(string siteName, string kind, string requestId, string status, string details)
+        {
+            var info = new DeploymentCompletedInfo
+            {
+                TimeStamp = $"{DateTime.UtcNow:s}Z",
+                SiteName = siteName,
+                Kind = kind,
+                RequestId = requestId,
+                Status = status,
+                Details = details ?? string.Empty
+            };
+
+            try
+            {
+                var path = Path.Combine(System.Environment.ExpandEnvironmentVariables(@"%HOME%"), "site", "deployments");
+                var file = Path.Combine(path, $"{Constants.LatestDeployment}.json");
+                var content = JsonConvert.SerializeObject(info, Formatting.Indented);
+                FileSystemHelpers.EnsureDirectory(path);
+
+                // write deployment info to %home%\site\deployments\LatestDeployment.json
+                OperationManager.Attempt(() => FileSystemHelpers.Instance.File.WriteAllText(file, content));
+
+                _analytics.DeploymentCompleted(
+                    info.SiteName,
+                    info.Kind,
+                    info.RequestId,
+                    info.Status,
+                    info.Details);
+            }
+            catch (Exception ex)
+            {
+                _analytics.UnexpectedException(ex);
+            }
+        }
+    }
+}

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -870,6 +870,27 @@ namespace Kudu.Core.Helpers
                                     .OrderBy(n => n);
         }
 
+        /// <summary>
+        /// This common codes is to invoke post deployment operations.
+        /// It is written to require least dependencies but framework assemblies.
+        /// Caller is responsible for synchronization.
+        /// </summary>
+        /// <param name="siteName">WEBSITE_SITE_NAME env</param>
+        /// <param name="kind">MSDeploy, ZipDeploy, Git, ..</param>
+        /// <param name="requestId">for correlation</param>
+        /// <param name="status">Success or fail</param>
+        /// <param name="details">deployment specific json</param>
+        /// <param name="tracer">tracing</param>
+        public static async Task InvokeWithDetails(string kind, string requestId, string status, string details, TraceListener tracer)
+        {
+            DeploymentCompletedInfo.Persist(System.Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"), kind, requestId, status, details);
+
+            if (string.Equals("Success", status, StringComparison.OrdinalIgnoreCase))
+            {
+                await Invoke(requestId, tracer);
+            }
+        }
+
         private static void Trace(TraceEventType eventType, string message)
         {
             Trace(eventType, "{0}", message);

--- a/Kudu.Core/Tracing/IAnalytics.cs
+++ b/Kudu.Core/Tracing/IAnalytics.cs
@@ -18,5 +18,7 @@ namespace Kudu.Core.Tracing
         void DeprecatedApiUsed(string route, string userAgent, string method, string path);
 
         void SiteExtensionEvent(string method, string path, string result, string deploymentDurationInMilliseconds, string Message);
+
+        void DeploymentCompleted(string siteName, string kind, string requestId, string status, string details);
     }
 }

--- a/Kudu.Core/Tracing/KuduEvent.cs
+++ b/Kudu.Core/Tracing/KuduEvent.cs
@@ -32,6 +32,8 @@ namespace Kudu.Core.Tracing
         public string verb = string.Empty;
         public int statusCode = 0;
         public long latencyInMilliseconds = 0;
+        public string deploymentDetails = string.Empty;
+        public string deploymentStatus = string.Empty;
 
         public override string ToString()
         {

--- a/Kudu.Core/Tracing/KuduEventGenerator.cs
+++ b/Kudu.Core/Tracing/KuduEventGenerator.cs
@@ -33,6 +33,7 @@ namespace Kudu.Core.Tracing
                     }
                     else
                     {
+                        // Log4Net logger output to a file when running on Linux
                         _eventGenerator = new Log4NetEventGenerator();
                     }
                 }

--- a/Kudu.Core/Tracing/KuduEventSource.cs
+++ b/Kudu.Core/Tracing/KuduEventSource.cs
@@ -72,6 +72,24 @@ namespace Kudu.Core.Tracing
             }
         }
 
+        /// <summary>
+        /// DeploymentCompleted event
+        /// </summary>
+        /// <param name="siteName">WEBSITE_SITE_NAME</param>
+        /// <param name="kind">MSDeploy, ZipDeploy, Git, ...</param>
+        /// <param name="requestId">requestId</param>
+        /// <param name="status">Success, Failed</param>
+        /// <param name="details">deployment-specific json</param>
+        [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters")]
+        [Event(65516, Level = EventLevel.Informational, Message = "Deployment completed for site {0}", Channel = EventChannel.Operational)]
+        public void DeploymentCompleted(string siteName, string kind, string requestId, string status, string details)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(65516, siteName, kind, requestId, status, details);
+            }
+        }
+
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters")]
         [Event(65515, Level = EventLevel.Informational, Message = "Api event for site {0}", Channel = EventChannel.Operational)]
         public void ApiEvent(string siteName, string Message, string address, string verb, string requestId, int statusCode, long latencyInMilliseconds, string userAgent)

--- a/Kudu.Core/Tracing/LinuxContainerEventGenerator.cs
+++ b/Kudu.Core/Tracing/LinuxContainerEventGenerator.cs
@@ -32,6 +32,19 @@ namespace Kudu.Core.Tracing
             LogKuduTraceEvent(kuduEvent);
         }
 
+        public void DeploymentCompleted(string siteName, string kind, string requestId, string status, string details)
+        {
+            KuduEvent kuduEvent = new KuduEvent
+            {
+                siteName = siteName,
+                deploymentDetails = details,
+                deploymentStatus = status,
+                requestId = requestId,
+            };
+
+            LogKuduTraceEvent(kuduEvent);
+        }
+
         public void WebJobStarted(string siteName, string jobName, string scriptExtension, string jobType, string siteMode, string error, string trigger)
         {
             KuduEvent kuduEvent = new KuduEvent

--- a/Kudu.Core/Tracing/Log4NetEventGenerator.cs
+++ b/Kudu.Core/Tracing/Log4NetEventGenerator.cs
@@ -33,6 +33,19 @@ namespace Kudu.Core.Tracing
             LogKuduTraceEvent(kuduEvent);
         }
 
+        public void DeploymentCompleted(string siteName, string kind, string requestId, string status, string details)
+        {
+            KuduEvent kuduEvent = new KuduEvent
+            {
+                siteName = siteName,
+                deploymentDetails = details,
+                deploymentStatus = status,
+                requestId = requestId,
+            };
+
+            LogKuduTraceEvent(kuduEvent);
+        }
+
         public void WebJobStarted(string siteName, string jobName, string scriptExtension, string jobType, string siteMode, string error, string trigger)
         {
             KuduEvent kuduEvent = new KuduEvent

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
@@ -27,7 +25,6 @@ using Newtonsoft.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using Kudu.Services.Zip;
 using System.IO.Compression;
 
 namespace Kudu.Services.Deployment

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -31,7 +31,9 @@ namespace Kudu.Services.Deployment
 {
     public class PushDeploymentController : Controller
     {
-        private const string DefaultDeployer = "Push-Deployer";
+        private const string ZipDeploy = "ZipDeploy";
+        private const string ZipDeployUrl = "ZipDeploy-via-url";
+        private const string WarDeploy = "WarDeploy";
         private const string DefaultMessage = "Created via a push deployment";
 
         private readonly IEnvironment _environment;
@@ -64,7 +66,7 @@ namespace Kudu.Services.Deployment
             [FromQuery] bool overwriteWebsiteRunFromPackage = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
-            [FromQuery] string deployer = DefaultDeployer,
+            [FromQuery] string deployer = ZipDeploy,
             [FromQuery] string message = DefaultMessage)
         {
             using (_tracer.Step("ZipPushDeploy"))
@@ -117,7 +119,7 @@ namespace Kudu.Services.Deployment
             [FromQuery] bool overwriteWebsiteRunFromPackage = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
-            [FromQuery] string deployer = DefaultDeployer,
+            [FromQuery] string deployer = ZipDeployUrl,
             [FromQuery] string message = DefaultMessage)
         {
             using (_tracer.Step("ZipPushDeployViaUrl"))
@@ -158,7 +160,7 @@ namespace Kudu.Services.Deployment
             [FromQuery] bool isAsync = false,
             [FromQuery] string author = null,
             [FromQuery] string authorEmail = null,
-            [FromQuery] string deployer = DefaultDeployer,
+            [FromQuery] string deployer = WarDeploy,
             [FromQuery] string message = DefaultMessage)
         {
             using (_tracer.Step("WarPushDeploy"))


### PR DESCRIPTION
This PR introduces a new analytics log event to trace the complete deployment info. This would further help us analyze the deployment failures and catch regressions early.

 
