### PR TITLE
Adding switch for Python builds to fallback to old behaviour

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -178,5 +178,8 @@ namespace Kudu
         public const string OneDeploy = "OneDeploy";
 
         public const string ScmDeploymentIdHeader = "SCM-DEPLOYMENT-ID";
+
+        public const string KuduBuildVersionAppSetting = "KUDU_BUILD_VERSION";
+        public const string PythonKuduBuild90 = "0.0.1";
     }
 }

--- a/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
@@ -246,7 +246,7 @@ namespace Kudu.Core.Deployment
                     }
                     else if (Language == Framework.Python)
                     {
-                        OryxArgumentsHelper.AddPythonCompressOption(args);
+                        OryxArgumentsHelper.AddPythonCompressOption(args, "tar-gz");
                     }
 
                     break;
@@ -259,7 +259,7 @@ namespace Kudu.Core.Deployment
                     }
                     else if (Language == Framework.Python)
                     {
-                        OryxArgumentsHelper.AddPythonCompressOption(args);
+                        OryxArgumentsHelper.AddPythonCompressOption(args, "zip");
                     }
 
                     break;

--- a/Kudu.Core/Deployment/Oryx/OryxArgumentsHelper.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxArgumentsHelper.cs
@@ -31,9 +31,17 @@ namespace Kudu.Core.Deployment.Oryx
             args.AppendFormat(" -p compress_node_modules={0}", format);
         }
 
-        internal static void AddPythonCompressOption(StringBuilder args)
+        internal static void AddPythonCompressOption(StringBuilder args, string format)
         {
-            args.Append(" --compress-destination-dir");
+            string pythonBuildVersion = System.Environment.GetEnvironmentVariable(Constants.KuduBuildVersionAppSetting);
+            if(!string.IsNullOrEmpty(pythonBuildVersion) && pythonBuildVersion.Trim().Equals(Constants.PythonKuduBuild90))
+            {
+                args.AppendFormat(" -p compress_virtualenv={0}", format);
+            }
+            else
+            {
+                args.Append(" --compress-destination-dir");
+            }
         }
 
         internal static void AddPythonVirtualEnv(StringBuilder args, string virtualEnv)


### PR DESCRIPTION
Adding app setting KUDU_BUILD_VERSION and setting it to 0.0.1 will make app service build Python apps by using previous behaviour where build output is compressed and put into /home/site/wwwroot(ANT90). If this flag is set to any other value than 0.0.1 or not set at all, then we default to new behaviour where Python apps will be built in /tmp/_GUID_ and user directly ssh into this path through webssh(ANT91).

