### PR TITLE
OneDeploy improvements

### DIFF
--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -5,22 +5,24 @@ using Kudu.Core.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Kudu.Services.Deployment
 {
     static class OneDeployHelper
     {
-        private const string StackEnvVarName = "WEBSITE_STACK";
-
         // Stacks supported by OneDeploy 
         public const string Tomcat = "TOMCAT";
         public const string JavaSE = "JAVA";
         public const string JBossEap = "JBOSSEAP";
 
+        private const string StackEnvVarName = "WEBSITE_STACK";
+
         // All paths are relative to HOME directory
-        private const string ScriptsDirectoryRelativePath = "site/scripts";
-        private const string LibsDirectoryRelativePath = "site/libs";
+        public const string WwwrootDirectoryRelativePath = "site/wwwroot";
+        public const string ScriptsDirectoryRelativePath = "site/scripts";
+        public const string LibsDirectoryRelativePath = "site/libs";
 
         public static bool IsLegacyWarPathValid(string path)
         {
@@ -31,29 +33,60 @@ namespace Kudu.Services.Deployment
 
             var segments = path.Split('/');
 
-            return segments.Length == 2 && path.StartsWith("webapps/") & !string.IsNullOrWhiteSpace(segments[1]);
+            return segments.Length == 2 && path.StartsWith("webapps/", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(segments[1]);
         }
 
-        public static bool EnsureValidStack(string expectedStack, bool ignoreStack, out string error)
+        public static bool EnsureValidStack(ArtifactType artifactType, List<string> expectedStacks, bool ignoreStack, out string error)
         {
             var websiteStack = GetWebsiteStack();
 
-            if (ignoreStack || string.Equals(websiteStack, expectedStack, StringComparison.OrdinalIgnoreCase))
+            bool isStackValid = expectedStacks != null && expectedStacks.Any(stack => string.Equals(websiteStack, stack, StringComparison.OrdinalIgnoreCase));
+
+            if (ignoreStack || isStackValid)
             {
                 error = null;
                 return true;
             }
 
-            error = $"WAR files cannot be deployed to stack='{websiteStack}'. Expected stack='{expectedStack}'";
+            error = $"Artifact type = '{artifactType}' cannot be deployed to stack = '{websiteStack}'. " +
+                    $"Site should be configured to run with stack = {string.Join(" or ", expectedStacks)}";
             return false;
         }
 
-        public static bool EnsureValidPath(ArtifactType artifactType, string path, out string error)
+        public static bool EnsureValidPath(ArtifactType artifactType, string designatedDirectoryRelativePath, ref string path, out string error)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 error = $"Path must be defined for type='{artifactType}'";
                 return false;
+            }
+
+            // Keep things simple by disallowing trailing slash
+            if (path.EndsWith("/", StringComparison.Ordinal))
+            {
+                error = $"Path cannot end with a '/'";
+                return false;
+            }
+
+            // If specified path is absolute, make sure it points to the designated directory for the artifact type
+            if (path.StartsWith("/", StringComparison.Ordinal))
+            {
+                string designatedRootAbsolutePath = $"/home/{designatedDirectoryRelativePath}/";
+
+                if (!path.StartsWith($"{designatedRootAbsolutePath}", StringComparison.Ordinal))
+                {
+                    error = $"Absolute path = '{path}' for artifact type = '{artifactType}' is invalid. " +
+                            $"Either use a relative path or use an absolute path that start with prefix '{designatedRootAbsolutePath}'";
+                    return false;
+                }
+
+                path = path.Substring(designatedRootAbsolutePath.Length);
+
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    error = $"Absolute path for artifact type = '{artifactType}' should be of the form {designatedRootAbsolutePath}[directoryname/]<filename>";
+                    return false;
+                }
             }
 
             error = null;
@@ -65,14 +98,9 @@ namespace Kudu.Services.Deployment
             return System.Environment.GetEnvironmentVariable(StackEnvVarName);
         }
 
-        public static string GetLibsDirectoryAbsolutePath(IEnvironment environment)
+        public static string GetAbsolutePath(IEnvironment environment, string relativePath)
         {
-            return Path.Combine(environment.RootPath, LibsDirectoryRelativePath);
-        }
-
-        public static string GetScriptsDirectoryAbsolutePath(IEnvironment environment)
-        {
-            return Path.Combine(environment.RootPath, ScriptsDirectoryRelativePath);
+            return Path.Combine(environment.RootPath, relativePath);
         }
 
         public static string GetStartupFileName()
@@ -80,13 +108,18 @@ namespace Kudu.Services.Deployment
             return OSDetector.IsOnWindows() ? "startup.cmd" : "startup.sh";
         }
 
-        public static void SetTargetSubDirectoyAndFileNameFromPath(DeploymentInfoBase deploymentInfo, string relativeFilePath)
+        // Extract directory path and file name from relativeFilePath
+        // Example: path=a/b/c.jar => TargetSubDirectoryRelativePath=a/b and TargetFileName=c.jar
+        // Example: path=c.jar => TargetSubDirectoryRelativePath=null and TargetFileName=c.jar
+        // Example: path=/c.jar => TargetSubDirectoryRelativePath="" and TargetFileName=c.jar
+        // Example: path=null => TargetSubDirectoryRelativePath=null and TargetFileName=null
+        public static void SetTargetSubDirectoyAndFileNameFromRelativePath(DeploymentInfoBase deploymentInfo, string relativeFilePath)
         {
-            // Extract directory path and file name from relativeFilePath
-            // Example: path=a/b/c.jar => TargetDirectoryName=a/b and TargetFileName=c.jar
-            // Example: path=c.jar => TargetDirectoryName=null and TargetFileName=c.jar
-            // Example: path=/c.jar => TargetDirectoryName="" and TargetFileName=c.jar
-            // Example: path=null => TargetDirectoryName=null and TargetFileName=null
+            if (relativeFilePath != null)
+            {
+                relativeFilePath = relativeFilePath.TrimStart('/');
+            }
+
             deploymentInfo.TargetFileName = Path.GetFileName(relativeFilePath);
             deploymentInfo.TargetSubDirectoryRelativePath = Path.GetDirectoryName(relativeFilePath);
         }

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -314,7 +314,7 @@ namespace Kudu.Services.Deployment
                 switch (artifactType)
                 {
                     case ArtifactType.War:
-                        if (!OneDeployHelper.EnsureValidStack(OneDeployHelper.Tomcat, ignoreStack, out error))
+                        if (!OneDeployHelper.EnsureValidStack(artifactType, new List<string> { OneDeployHelper.Tomcat, OneDeployHelper.JBossEap }, ignoreStack, out error))
                         {
                             return StatusCode400(error);
                         }
@@ -326,9 +326,15 @@ namespace Kudu.Services.Deployment
                             // For legacy war deployments, the only path allowed is webapps/<directory-name>
                             //
 
+                            if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.WwwrootDirectoryRelativePath, ref path, out error))
+                            {
+                                return StatusCode400(error);
+                            }
+
                             if (!OneDeployHelper.IsLegacyWarPathValid(path))
                             {
-                                return StatusCode400($"path='{path}'. Only allowed path when type={artifactType} is webapps/<directory-name>. Example: path=webapps/ROOT");
+                                return StatusCode400($"path='{path}' is invalid. When type={artifactType}, the only allowed paths are webapps/<directory-name> or /home/site/wwwroot/webapps/<directory-name>. " +
+                                                     $"Example: path=webapps/ROOT or path=/home/site/wwwroot/webapps/ROOT");
                             }
 
                             deploymentInfo.TargetRootPath = Path.Combine(_environment.WebRootPath, path);
@@ -348,7 +354,7 @@ namespace Kudu.Services.Deployment
                         break;
 
                     case ArtifactType.Jar:
-                        if (!OneDeployHelper.EnsureValidStack(OneDeployHelper.JavaSE, ignoreStack, out error))
+                        if (!OneDeployHelper.EnsureValidStack(artifactType, new List<string> { OneDeployHelper.JavaSE }, ignoreStack, out error))
                         {
                             return StatusCode400(error);
                         }
@@ -357,7 +363,7 @@ namespace Kudu.Services.Deployment
                         break;
 
                     case ArtifactType.Ear:
-                        if (!OneDeployHelper.EnsureValidStack(OneDeployHelper.JBossEap, ignoreStack, out error))
+                        if (!OneDeployHelper.EnsureValidStack(artifactType, new List<string> { OneDeployHelper.JBossEap }, ignoreStack, out error))
                         {
                             return StatusCode400(error);
                         }
@@ -366,38 +372,38 @@ namespace Kudu.Services.Deployment
                         break;
 
                     case ArtifactType.Lib:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, path, out error))
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.LibsDirectoryRelativePath, ref path, out error))
                         {
                             return StatusCode400(error);
                         }
 
-                        deploymentInfo.TargetRootPath = OneDeployHelper.GetLibsDirectoryAbsolutePath(_environment);
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromPath(deploymentInfo, path);
+                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.LibsDirectoryRelativePath);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
                         break;
 
                     case ArtifactType.Startup:
-                        deploymentInfo.TargetRootPath = OneDeployHelper.GetScriptsDirectoryAbsolutePath(_environment);
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromPath(deploymentInfo, OneDeployHelper.GetStartupFileName());
+                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, OneDeployHelper.GetStartupFileName());
                         break;
 
                     case ArtifactType.Script:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, path, out error))
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.ScriptsDirectoryRelativePath, ref path, out error))
                         {
                             return StatusCode400(error);
                         }
 
-                        deploymentInfo.TargetRootPath = OneDeployHelper.GetScriptsDirectoryAbsolutePath(_environment);
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromPath(deploymentInfo, path);
+                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
 
                         break;
 
                     case ArtifactType.Static:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, path, out error))
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.WwwrootDirectoryRelativePath, ref path, out error))
                         {
                             return StatusCode400(error);
                         }
 
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromPath(deploymentInfo, path);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
 
                         break;
 


### PR DESCRIPTION
- This is a port of https://github.com/projectkudu/kudu/pull/3248/
- Allow absolute paths. Earlier implementation only allows relative paths
- Allow WAR to be deployed to JBoss EAP (although it is not supported on Windows, this will help consistency with KuduLite)